### PR TITLE
Implement first-principles memory modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+flate2 = "1"
+tar = "0.4"
 
 [dev-dependencies]
 proptest = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,12 @@
 
 pub mod temporal_indexer;
 pub mod procedural_cache;
+pub mod memory_record;
+pub mod memory_store;
+pub mod memory_processor;
+pub mod memory_query;
+pub mod snapshot_manager;
+pub mod memory_cli;
 pub mod symbolic_store;
 pub mod perception_adapter;
 pub mod integration_layer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,84 +1,10 @@
-mod temporal_indexer;
-mod procedural_cache;
-mod symbolic_store;
-mod perception_adapter;
-mod integration_layer;
-mod aureus_bridge;
+mod memory_record;
+mod memory_store;
+mod memory_processor;
+mod memory_query;
+mod snapshot_manager;
+mod memory_cli;
 
-use temporal_indexer::{TemporalIndexer, TemporalTrace};
-use procedural_cache::{ProceduralCache, ProceduralTrace, FSMState, FSMTransition};
-use symbolic_store::SymbolicStore;
-use perception_adapter::{PerceptionAdapter, PerceptInput, Modality};
-use uuid::Uuid;
-use std::time::SystemTime;
-use std::collections::HashMap;
-
-fn main() {
-    // Temporal Indexer Example
-    let mut indexer = TemporalIndexer::new(100, 3600);
-    let trace = TemporalTrace {
-        id: Uuid::new_v4(),
-        timestamp: SystemTime::now(),
-        data: "Hello, HipCortex!",
-        relevance: 1.0,
-        decay_factor: 0.5,
-        last_access: SystemTime::now(),
-    };
-    indexer.insert(trace);
-    indexer.decay_and_prune();
-    let traces = indexer.get_recent(5);
-    for t in traces {
-        println!("[Temporal] {:?}", t);
-    }
-
-    // Procedural FSM Example
-    let mut proc_cache = ProceduralCache::new();
-    let fsm_trace = ProceduralTrace {
-        id: Uuid::new_v4(),
-        current_state: FSMState::Start,
-        memory: std::collections::HashMap::new(),
-    };
-    proc_cache.add_trace(fsm_trace.clone());
-    proc_cache.add_transition(FSMTransition {
-        from: FSMState::Start,
-        to: FSMState::Observe,
-        condition: None,
-    });
-    proc_cache.add_transition(FSMTransition {
-        from: FSMState::Observe,
-        to: FSMState::Reason,
-        condition: Some("perceived".to_string()),
-    });
-    let _ = proc_cache.advance(fsm_trace.id, None);
-    let state = proc_cache.advance(fsm_trace.id, Some("perceived"));
-    println!("[Procedural FSM] State after advance: {:?}", state);
-
-    // Symbolic Store Example
-    let mut sym_store = SymbolicStore::new();
-    let mut props = HashMap::new();
-    props.insert("type".to_string(), "concept".to_string());
-    let node_a = sym_store.add_node("A", props.clone());
-    let node_b = sym_store.add_node("B", props.clone());
-    sym_store.add_edge(node_a, node_b, "related_to");
-    let neighbors = sym_store.neighbors(node_a, Some("related_to"));
-    for n in neighbors {
-        println!("[SymbolicStore] Neighbor: {:?}", n);
-    }
-
-    // Perception Adapter Example
-    let input = PerceptInput {
-        modality: Modality::Text,
-        text: Some("This is a test percept".to_string()),
-        embedding: None,
-        tags: vec!["demo".to_string()],
-    };
-    PerceptionAdapter::adapt(input);
-
-    // Integration Layer Example
-    let integration = integration_layer::IntegrationLayer::new();
-    integration.connect();
-
-    // Aureus Bridge Example
-    let aureus = aureus_bridge::AureusBridge::new();
-    aureus.reflexion_loop();
+fn main() -> anyhow::Result<()> {
+    memory_cli::run()
 }

--- a/src/memory_cli.rs
+++ b/src/memory_cli.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use chrono::{DateTime, Utc};
+
+use crate::memory_record::{MemoryRecord, MemoryType};
+use crate::memory_store::MemoryStore;
+use crate::snapshot_manager::SnapshotManager;
+
+#[derive(Parser)]
+#[command(name = "hipcortex", version, about = "Minimal Memory CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Add a memory record
+    Add {
+        #[arg(long)]
+        actor: String,
+        #[arg(long)]
+        action: String,
+        #[arg(long)]
+        target: String,
+    },
+    /// Query records
+    Query {
+        #[arg(long)]
+        r#type: Option<MemoryType>,
+        #[arg(long)]
+        actor: Option<String>,
+        #[arg(long)]
+        since: Option<DateTime<Utc>>,
+    },
+    /// Save snapshot
+    Snapshot {
+        tag: String,
+    },
+}
+
+pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let mut store = MemoryStore::new("memory.jsonl")?;
+    match cli.command {
+        Commands::Add { actor, action, target } => {
+            let record = MemoryRecord::new(
+                MemoryType::Temporal,
+                actor,
+                action,
+                target,
+                serde_json::json!({}),
+            );
+            store.add(record)?;
+        }
+        Commands::Query { r#type, actor, since } => {
+            let mut results: Vec<&MemoryRecord> = store.all().iter().collect();
+            if let Some(t) = r#type {
+                results = results.into_iter().filter(|r| r.record_type == t).collect();
+            }
+            if let Some(a) = actor {
+                results = results.into_iter().filter(|r| r.actor == a).collect();
+            }
+            if let Some(ts) = since {
+                results = results.into_iter().filter(|r| r.timestamp >= ts).collect();
+            }
+            for r in results {
+                println!("{:?}", r);
+            }
+        }
+        Commands::Snapshot { tag } => {
+            SnapshotManager::save("memory.jsonl", &tag)?;
+        }
+    }
+    Ok(())
+}

--- a/src/memory_processor.rs
+++ b/src/memory_processor.rs
@@ -1,0 +1,12 @@
+use std::collections::HashSet;
+
+use crate::memory_record::MemoryRecord;
+
+pub struct MemoryProcessor;
+
+impl MemoryProcessor {
+    pub fn deduplicate(records: &mut Vec<MemoryRecord>) {
+        let mut seen = HashSet::new();
+        records.retain(|r| seen.insert(r.id));
+    }
+}

--- a/src/memory_query.rs
+++ b/src/memory_query.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+
+use crate::memory_record::{MemoryRecord, MemoryType};
+
+pub struct MemoryQuery;
+
+impl MemoryQuery {
+    pub fn by_type<'a>(records: &'a [MemoryRecord], t: MemoryType) -> Vec<&'a MemoryRecord> {
+        records.iter().filter(|r| r.record_type == t).collect()
+    }
+
+    pub fn by_actor<'a>(records: &'a [MemoryRecord], actor: &str) -> Vec<&'a MemoryRecord> {
+        records.iter().filter(|r| r.actor == actor).collect()
+    }
+
+    pub fn since<'a>(records: &'a [MemoryRecord], ts: DateTime<Utc>) -> Vec<&'a MemoryRecord> {
+        records.iter().filter(|r| r.timestamp >= ts).collect()
+    }
+}

--- a/src/memory_record.rs
+++ b/src/memory_record.rs
@@ -1,0 +1,39 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+pub enum MemoryType {
+    Temporal,
+    Symbolic,
+    Procedural,
+    Reflexion,
+    Perception,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryRecord {
+    pub id: Uuid,
+    pub record_type: MemoryType,
+    pub timestamp: DateTime<Utc>,
+    pub actor: String,
+    pub action: String,
+    pub target: String,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+impl MemoryRecord {
+    pub fn new(record_type: MemoryType, actor: String, action: String, target: String, metadata: serde_json::Value) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            record_type,
+            timestamp: Utc::now(),
+            actor,
+            action,
+            target,
+            metadata,
+        }
+    }
+}

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -1,0 +1,49 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::memory_record::MemoryRecord;
+
+pub struct MemoryStore {
+    path: PathBuf,
+    records: Vec<MemoryRecord>,
+}
+
+impl MemoryStore {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path_buf = path.as_ref().to_path_buf();
+        let mut records = Vec::new();
+        if path_buf.exists() {
+            let file = File::open(&path_buf)?;
+            let reader = BufReader::new(file);
+            for line in reader.lines() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let rec: MemoryRecord = serde_json::from_str(&line)?;
+                records.push(rec);
+            }
+        }
+        Ok(Self { path: path_buf, records })
+    }
+
+    pub fn add(&mut self, record: MemoryRecord) -> Result<()> {
+        self.records.push(record.clone());
+        let mut file = OpenOptions::new().create(true).append(true).open(&self.path)?;
+        serde_json::to_writer(&mut file, &record)?;
+        file.write_all(b"\n")?;
+        Ok(())
+    }
+
+    pub fn all(&self) -> &[MemoryRecord] {
+        &self.records
+    }
+
+    pub fn clear(&mut self) {
+        self.records.clear();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}

--- a/src/snapshot_manager.rs
+++ b/src/snapshot_manager.rs
@@ -1,5 +1,7 @@
 use std::fs::{File};
 use std::path::{Path, PathBuf};
+use flate2::read::GzDecoder;
+use tar::Archive;
 
 use anyhow::Result;
 use flate2::{write::GzEncoder, Compression};
@@ -16,5 +18,13 @@ impl SnapshotManager {
         tar.append_path(source.as_ref())?;
         tar.finish()?;
         Ok(archive_path)
+    }
+
+    pub fn load<P: AsRef<Path>, Q: AsRef<Path>>(archive: P, dest: Q) -> Result<()> {
+        let tar_gz = File::open(&archive)?;
+        let dec = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(dec);
+        archive.unpack(dest)?;
+        Ok(())
     }
 }

--- a/src/snapshot_manager.rs
+++ b/src/snapshot_manager.rs
@@ -1,0 +1,20 @@
+use std::fs::{File};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use flate2::{write::GzEncoder, Compression};
+use tar::Builder;
+
+pub struct SnapshotManager;
+
+impl SnapshotManager {
+    pub fn save<P: AsRef<Path>>(source: P, tag: &str) -> Result<PathBuf> {
+        let archive_path = source.as_ref().with_extension(format!("{}.tar.gz", tag));
+        let tar_gz = File::create(&archive_path)?;
+        let enc = GzEncoder::new(tar_gz, Compression::default());
+        let mut tar = Builder::new(enc);
+        tar.append_path(source.as_ref())?;
+        tar.finish()?;
+        Ok(archive_path)
+    }
+}

--- a/tests/memory_store_tests.rs
+++ b/tests/memory_store_tests.rs
@@ -1,0 +1,16 @@
+use hipcortex::memory_record::{MemoryRecord, MemoryType};
+use hipcortex::memory_store::MemoryStore;
+use std::fs;
+
+#[test]
+fn test_add_and_query_memory_store() {
+    let path = "test_memory.jsonl";
+    let _ = fs::remove_file(path);
+    let mut store = MemoryStore::new(path).unwrap();
+    let record = MemoryRecord::new(MemoryType::Symbolic, "user".into(), "is".into(), "tester".into(), serde_json::json!({}));
+    store.add(record.clone()).unwrap();
+    let all = store.all();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].actor, "user");
+    fs::remove_file(path).unwrap();
+}

--- a/tests/snapshot_manager_tests.rs
+++ b/tests/snapshot_manager_tests.rs
@@ -1,0 +1,21 @@
+use hipcortex::memory_record::{MemoryRecord, MemoryType};
+use hipcortex::memory_store::MemoryStore;
+use hipcortex::snapshot_manager::SnapshotManager;
+use std::fs;
+
+#[test]
+fn test_snapshot_save_and_load() {
+    let path = "snap_memory.jsonl";
+    let _ = fs::remove_file(path);
+    let mut store = MemoryStore::new(path).unwrap();
+    let record = MemoryRecord::new(MemoryType::Temporal, "agent".into(), "do".into(), "something".into(), serde_json::json!({}));
+    store.add(record.clone()).unwrap();
+    let archive = SnapshotManager::save(path, "testsnap").unwrap();
+    fs::remove_file(path).unwrap();
+    SnapshotManager::load(&archive, ".").unwrap();
+    let store2 = MemoryStore::new(path).unwrap();
+    assert_eq!(store2.all().len(), 1);
+    fs::remove_file(path).unwrap();
+    fs::remove_file(archive).unwrap();
+}
+


### PR DESCRIPTION
## Summary
- add MemoryRecord schema with typed memory representation
- implement MemoryStore with JSONL persistence
- provide CLI utilities for adding, querying and snapshotting memory
- expose helper modules in library
- add basic tests for memory store

## Testing
- `cargo test --quiet`
