### PR TITLE
Add SIT, UAT, regression and performance tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ uuid = { version = "1", features = ["v4"] }
 proptest = "1"
 criterion = "0.5"
 
+[[bench]]
+name = "temporal_indexer_bench"
+harness = false
+

--- a/benches/temporal_indexer_bench.rs
+++ b/benches/temporal_indexer_bench.rs
@@ -1,0 +1,26 @@
+use criterion::{black_box, Criterion, criterion_group, criterion_main};
+use uuid::Uuid;
+use std::time::SystemTime;
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+
+fn bench_insert(c: &mut Criterion) {
+    c.bench_function("insert 100 traces", |b| {
+        b.iter(|| {
+            let mut indexer = TemporalIndexer::new(100, 3600);
+            for _ in 0..100 {
+                let trace = TemporalTrace {
+                    id: Uuid::new_v4(),
+                    timestamp: SystemTime::now(),
+                    data: "trace",
+                    relevance: 1.0,
+                    decay_factor: 0.5,
+                    last_access: SystemTime::now(),
+                };
+                indexer.insert(black_box(trace));
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_insert);
+criterion_main!(benches);

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -1,0 +1,27 @@
+use uuid::Uuid;
+use std::time::SystemTime;
+
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+
+#[test]
+fn get_recent_zero_returns_empty() {
+    let indexer: TemporalIndexer<i32> = TemporalIndexer::new(2, 3600);
+    let results = indexer.get_recent(0);
+    assert!(results.is_empty());
+}
+
+#[test]
+fn inserting_trace_preserves_id() {
+    let mut indexer = TemporalIndexer::new(2, 3600);
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: 42,
+        relevance: 1.0,
+        decay_factor: 0.5,
+        last_access: SystemTime::now(),
+    };
+    let expected_id = trace.id;
+    indexer.insert(trace);
+    assert_eq!(indexer.get_recent(1)[0].id, expected_id);
+}

--- a/tests/system_integration_tests.rs
+++ b/tests/system_integration_tests.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use hipcortex::symbolic_store::SymbolicStore;
+use hipcortex::perception_adapter::{PerceptionAdapter, PerceptInput, Modality};
+use hipcortex::integration_layer::IntegrationLayer;
+use hipcortex::aureus_bridge::AureusBridge;
+
+#[test]
+fn memory_round_trip() {
+    let mut indexer = TemporalIndexer::new(4, 3600);
+    let mut store = SymbolicStore::new();
+    let node_id = store.add_node("city", HashMap::new());
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: node_id,
+        relevance: 1.0,
+        decay_factor: 0.5,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some("travel".to_string()),
+        embedding: None,
+        tags: vec![],
+    };
+    PerceptionAdapter::adapt(input);
+
+    assert!(store.get_node(node_id).is_some());
+    assert_eq!(indexer.get_recent(1)[0].data, node_id);
+}
+
+#[test]
+fn integration_and_reflexion() {
+    let layer = IntegrationLayer::new();
+    layer.connect();
+    let aureus = AureusBridge::new();
+    aureus.reflexion_loop();
+}
+

--- a/tests/test_report/PerformanceTestReport.md
+++ b/tests/test_report/PerformanceTestReport.md
@@ -1,0 +1,9 @@
+# Performance Test Report
+
+*Date: June 5, 2025*
+
+Criterion benchmarks measure core operation speed.
+
+- **temporal_indexer_bench:** inserts 100 traces repeatedly to measure throughput.
+
+See `cargo bench` output for detailed timing results. The benchmark completes successfully.

--- a/tests/test_report/RegressionTestReport.md
+++ b/tests/test_report/RegressionTestReport.md
@@ -1,0 +1,10 @@
+# Regression Test Report
+
+*Date: June 5, 2025*
+
+Regression tests ensure previous functionality remains intact after changes.
+
+- **get_recent_zero_returns_empty:** verifies that requesting zero recent items yields an empty result.
+- **inserting_trace_preserves_id:** ensures inserted temporal traces keep their IDs when retrieved.
+
+All regression tests pass.

--- a/tests/test_report/SITTestReport.md
+++ b/tests/test_report/SITTestReport.md
@@ -1,0 +1,10 @@
+# System Integration Test Report
+
+*Date: June 5, 2025*
+
+This report summarizes the system integration tests validating interactions across modules.
+
+- **memory_round_trip:** inserts a symbolic node, stores it in temporal memory, adapts a perception input, and verifies retrieval.
+- **integration_and_reflexion:** initializes the IntegrationLayer and AureusBridge together without errors.
+
+All system integration tests pass, confirming basic cross-module functionality.

--- a/tests/test_report/UATTestReport.md
+++ b/tests/test_report/UATTestReport.md
@@ -1,0 +1,10 @@
+# User Acceptance Test Report
+
+*Date: June 5, 2025*
+
+These tests validate end user workflows using the memory engine.
+
+- **travelg3n_store_and_retrieve_city:** simulates storing a city and retrieving it via temporal memory.
+- **athena_reflexion_placeholder:** ensures the reflexion loop runs without panic.
+
+Both user acceptance tests pass, demonstrating typical user scenarios complete successfully.

--- a/tests/uat_tests.rs
+++ b/tests/uat_tests.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use hipcortex::symbolic_store::SymbolicStore;
+
+#[test]
+fn travelg3n_store_and_retrieve_city() {
+    let mut store = SymbolicStore::new();
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    let mut props = HashMap::new();
+    props.insert("type".to_string(), "city".to_string());
+    let city_id = store.add_node("Paris", props);
+
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: city_id,
+        relevance: 1.0,
+        decay_factor: 0.5,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+
+    let last_trace = indexer.get_recent(1)[0];
+    let city_node = store.get_node(last_trace.data).unwrap();
+    assert_eq!(city_node.label, "Paris");
+}
+
+#[test]
+fn athena_reflexion_placeholder() {
+    use hipcortex::aureus_bridge::AureusBridge;
+    let aureus = AureusBridge::new();
+    aureus.reflexion_loop();
+}


### PR DESCRIPTION
## Summary
- add system integration tests covering cross-module workflow
- add user acceptance tests for travel and reflexion scenarios
- add regression tests to prevent regressions in `TemporalIndexer`
- add Criterion benchmark for performance testing
- record test results in new markdown reports
- fix benchmark harness so `cargo bench` runs

## Testing
- `cargo test --all --quiet`
- `cargo bench --quiet`

