### PR TITLE
Add basic Tauri UI

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,5 +1,134 @@
 #[cfg(feature = "gui")]
+use std::sync::Mutex;
+#[cfg(feature = "gui")]
+use tauri::State;
+#[cfg(feature = "gui")]
+use serde::Serialize;
+
+#[cfg(feature = "gui")]
+use crate::{
+    symbolic_store::SymbolicStore,
+    procedural_cache::ProceduralCache,
+    temporal_indexer::TemporalIndexer,
+    aureus_bridge::AureusBridge,
+    perception_adapter::{PerceptionAdapter, PerceptInput, Modality},
+    memory_store::MemoryStore,
+    memory_record::{MemoryRecord, MemoryType},
+};
+
+#[cfg(feature = "gui")]
+pub struct GuiState {
+    symbolic: Mutex<SymbolicStore>,
+    temporal: Mutex<TemporalIndexer<String>>,
+    procedural: Mutex<ProceduralCache>,
+    aureus: Mutex<AureusBridge>,
+    memory: Mutex<MemoryStore>,
+}
+
+#[cfg(feature = "gui")]
+impl GuiState {
+    pub fn new() -> Self {
+        Self {
+            symbolic: Mutex::new(SymbolicStore::new()),
+            temporal: Mutex::new(TemporalIndexer::new(100, 3600)),
+            procedural: Mutex::new(ProceduralCache::new()),
+            aureus: Mutex::new(AureusBridge::new()),
+            memory: Mutex::new(MemoryStore::new("memory_gui.jsonl").unwrap()),
+        }
+    }
+}
+
+#[cfg(feature = "gui")]
+#[derive(Serialize)]
+struct NodeDto {
+    id: String,
+    label: String,
+}
+
+#[cfg(feature = "gui")]
+#[derive(Serialize)]
+struct EdgeDto {
+    from: String,
+    to: String,
+    relation: String,
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+fn get_symbolic_graph(state: State<GuiState>) -> (Vec<NodeDto>, Vec<EdgeDto>) {
+    let store = state.symbolic.lock().unwrap();
+    let nodes = store
+        .nodes
+        .values()
+        .map(|n| NodeDto {
+            id: n.id.to_string(),
+            label: n.label.clone(),
+        })
+        .collect();
+    let edges = store
+        .edges
+        .iter()
+        .map(|e| EdgeDto {
+            from: e.from.to_string(),
+            to: e.to.to_string(),
+            relation: e.relation.clone(),
+        })
+        .collect();
+    (nodes, edges)
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+fn run_reflexion(state: State<GuiState>) -> usize {
+    let mut bridge = state.aureus.lock().unwrap();
+    bridge.reflexion_loop();
+    bridge.loops_run()
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+fn send_perception(state: State<GuiState>, text: String) -> String {
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some(text.clone()),
+        embedding: None,
+        image_data: None,
+        tags: vec![],
+    };
+    PerceptionAdapter::adapt(input);
+    let mut mem = state.memory.lock().unwrap();
+    let rec = MemoryRecord::new(
+        MemoryType::Perception,
+        "user".into(),
+        "input".into(),
+        text.clone(),
+        serde_json::json!({}),
+    );
+    let _ = mem.add(rec);
+    format!("perceived: {}", text)
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+fn cli_command(state: State<GuiState>, cmd: String) -> String {
+    match cmd.as_str() {
+        "trace list" => {
+            let mem = state.memory.lock().unwrap();
+            format!("{} records", mem.all().len())
+        }
+        _ => format!("unknown command: {}", cmd),
+    }
+}
+
+#[cfg(feature = "gui")]
 pub fn launch() -> tauri::Result<()> {
     tauri::Builder::default()
+        .manage(GuiState::new())
+        .invoke_handler(tauri::generate_handler![
+            get_symbolic_graph,
+            run_reflexion,
+            send_perception,
+            cli_command
+        ])
         .run(tauri::generate_context!())
 }

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,0 +1,22 @@
+{
+  "package": {
+    "productName": "HipCortex",
+    "version": "0.1.0"
+  },
+  "build": {
+    "distDir": "ui",
+    "devPath": "ui"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "HipCortex UI",
+        "width": 1200,
+        "height": 800
+      }
+    ],
+    "allowlist": {
+      "all": true
+    }
+  }
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HipCortex UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="container">
+        <div id="graph" class="panel">
+            <h2>Symbolic Graph</h2>
+            <pre id="graph-data">Loading...</pre>
+        </div>
+        <div id="reflexion" class="panel">
+            <h2>Reflexion & FSM</h2>
+            <pre id="fsm-state">Idle</pre>
+            <button onclick="runReflexion()">Run Reflexion Loop</button>
+        </div>
+        <div id="perception" class="panel">
+            <h2>Perception Console</h2>
+            <textarea id="perception-input" rows="4" cols="30" placeholder="Type perception input"></textarea>
+            <button onclick="sendPerception()">Send</button>
+            <pre id="perception-log"></pre>
+        </div>
+        <div id="cli" class="panel">
+            <h2>CLI Shell</h2>
+            <input id="cli-cmd" type="text" placeholder="Command"/>
+            <button onclick="runCli()">Run</button>
+            <pre id="cli-out"></pre>
+        </div>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,0 +1,27 @@
+async function loadGraph() {
+    const data = await window.__TAURI__.invoke('get_symbolic_graph');
+    document.getElementById('graph-data').innerText = JSON.stringify(data, null, 2);
+}
+
+async function runReflexion() {
+    const loops = await window.__TAURI__.invoke('run_reflexion');
+    document.getElementById('fsm-state').innerText = 'Loops run: ' + loops;
+}
+
+async function sendPerception() {
+    const text = document.getElementById('perception-input').value;
+    const log = await window.__TAURI__.invoke('send_perception', { text });
+    document.getElementById('perception-log').innerText += log + '\n';
+    document.getElementById('perception-input').value = '';
+}
+
+async function runCli() {
+    const cmd = document.getElementById('cli-cmd').value;
+    const out = await window.__TAURI__.invoke('cli_command', { cmd });
+    document.getElementById('cli-out').innerText += out + '\n';
+    document.getElementById('cli-cmd').value = '';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadGraph();
+});

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,0 +1,24 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+}
+#container {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    height: 100vh;
+}
+.panel {
+    border-right: 1px solid #555;
+    padding: 10px;
+    overflow: auto;
+}
+.panel:last-child {
+    border-right: none;
+}
+pre {
+    background: #1e1e1e;
+    color: #c9d1d9;
+    padding: 8px;
+    height: 60vh;
+    overflow: auto;
+}


### PR DESCRIPTION
## Summary
- implement a minimal Tauri desktop UI under the `gui` feature
- expose commands for symbolic graph, reflexion loop, perception input and CLI
- add default configuration in `tauri.conf.json`
- provide HTML/JS/CSS assets implementing four UI panels

## Testing
- `cargo test`
