### PR TITLE
Add comprehensive automated tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,15 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 [dev-dependencies]
 proptest = "1"
 criterion = "0.5"
+assert_cmd = "2"
+predicates = "3"
 
 [[bench]]
 name = "temporal_indexer_bench"
+harness = false
+
+[[bench]]
+name = "symbolic_store_bench"
 harness = false
 
 

--- a/benches/symbolic_store_bench.rs
+++ b/benches/symbolic_store_bench.rs
@@ -1,0 +1,22 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use hipcortex::symbolic_store::SymbolicStore;
+use std::collections::HashMap;
+
+fn bench_insert(c: &mut Criterion) {
+    c.bench_function("symbolic insert", |b| {
+        b.iter(|| {
+            let mut store = SymbolicStore::new();
+            let mut last = None;
+            for i in 0..100 {
+                let id = store.add_node(&format!("n{}", i), HashMap::new());
+                if let Some(prev) = last {
+                    store.add_edge(prev, id, "rel");
+                }
+                last = Some(id);
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_insert);
+criterion_main!(benches);

--- a/fixtures/sample_memory_trace.json
+++ b/fixtures/sample_memory_trace.json
@@ -1,0 +1,9 @@
+{
+  "id": "00000000-0000-0000-0000-000000000006",
+  "record_type": "Temporal",
+  "timestamp": "2023-01-02T00:00:00Z",
+  "actor": "system",
+  "action": "test",
+  "target": "example",
+  "metadata": {}
+}

--- a/src/memory_processor.rs
+++ b/src/memory_processor.rs
@@ -10,3 +10,22 @@ impl MemoryProcessor {
         records.retain(|r| seen.insert(r.id));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deduplicate_removes_duplicates() {
+        let rec = MemoryRecord::new(
+            crate::memory_record::MemoryType::Temporal,
+            "a".into(),
+            "b".into(),
+            "c".into(),
+            serde_json::json!({}),
+        );
+        let mut vec = vec![rec.clone(), rec];
+        MemoryProcessor::deduplicate(&mut vec);
+        assert_eq!(vec.len(), 1);
+    }
+}

--- a/src/memory_query.rs
+++ b/src/memory_query.rs
@@ -17,3 +17,22 @@ impl MemoryQuery {
         records.iter().filter(|r| r.timestamp >= ts).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_by_actor() {
+        let rec = MemoryRecord::new(
+            MemoryType::Temporal,
+            "actor".into(),
+            "do".into(),
+            "thing".into(),
+            serde_json::json!({}),
+        );
+        let vec = vec![rec];
+        let results = MemoryQuery::by_actor(&vec, "actor");
+        assert_eq!(results.len(), 1);
+    }
+}

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -47,3 +47,25 @@ impl MemoryStore {
         let _ = std::fs::remove_file(&self.path);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_read() {
+        let path = "test_store.jsonl";
+        let _ = std::fs::remove_file(path);
+        let mut store = MemoryStore::new(path).unwrap();
+        let rec = MemoryRecord::new(
+            crate::memory_record::MemoryType::Symbolic,
+            "a".into(),
+            "b".into(),
+            "c".into(),
+            serde_json::json!({}),
+        );
+        store.add(rec).unwrap();
+        assert_eq!(store.all().len(), 1);
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/src/modules/aureus_bridge.rs
+++ b/src/modules/aureus_bridge.rs
@@ -73,3 +73,18 @@ impl AureusBridge {
         self.loops = 0;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_clients::mock::MockClient;
+
+    #[test]
+    fn run_loop_increments_counter() {
+        let mut bridge = AureusBridge::with_client(Box::new(MockClient));
+        let mut store = MemoryStore::new("test_bridge.jsonl").unwrap();
+        store.clear();
+        bridge.reflexion_loop("ctx", &mut store);
+        assert_eq!(bridge.loops_run(), 1);
+    }
+}

--- a/src/modules/integration_layer.rs
+++ b/src/modules/integration_layer.rs
@@ -58,3 +58,25 @@ impl IntegrationLayer {
         self.connected
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyLLM;
+    impl LLMClient for DummyLLM {
+        fn generate_response(&self, _prompt: &str) -> String {
+            "ok".to_string()
+        }
+    }
+
+    #[test]
+    fn connect_and_invoke() {
+        let mut layer = IntegrationLayer::new();
+        layer.connect();
+        layer.set_client(Box::new(DummyLLM));
+        assert!(layer.is_connected());
+        let resp = layer.invoke_llm("hi");
+        assert_eq!(resp.unwrap(), "ok");
+    }
+}

--- a/src/modules/perception_adapter.rs
+++ b/src/modules/perception_adapter.rs
@@ -50,3 +50,20 @@ impl PerceptionAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapt_text() {
+        let input = PerceptInput {
+            modality: Modality::Text,
+            text: Some("hi".to_string()),
+            embedding: None,
+            image_data: None,
+            tags: vec![],
+        };
+        PerceptionAdapter::adapt(input);
+    }
+}

--- a/src/modules/procedural_cache.rs
+++ b/src/modules/procedural_cache.rs
@@ -82,3 +82,26 @@ impl ProceduralCache {
         self.traces.get(&trace_id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_fsm_transition() {
+        let mut cache = ProceduralCache::new();
+        let trace = ProceduralTrace {
+            id: Uuid::new_v4(),
+            current_state: FSMState::Start,
+            memory: HashMap::new(),
+        };
+        cache.add_trace(trace.clone());
+        cache.add_transition(FSMTransition {
+            from: FSMState::Start,
+            to: FSMState::Observe,
+            condition: None,
+        });
+        let new_state = cache.advance(trace.id, None);
+        assert_eq!(new_state, Some(FSMState::Observe));
+    }
+}

--- a/src/modules/symbolic_store.rs
+++ b/src/modules/symbolic_store.rs
@@ -98,3 +98,17 @@ impl SymbolicStore {
         existed
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_node_and_edge() {
+        let mut store = SymbolicStore::new();
+        let id_a = store.add_node("A", HashMap::new());
+        let id_b = store.add_node("B", HashMap::new());
+        store.add_edge(id_a, id_b, "rel");
+        assert_eq!(store.neighbors(id_a, Some("rel")).len(), 1);
+    }
+}

--- a/src/modules/temporal_indexer.rs
+++ b/src/modules/temporal_indexer.rs
@@ -76,7 +76,27 @@ impl<T> TemporalIndexer<T> {
         None
     }
 
-    pub fn get_recent(&self, n: usize) -> Vec<&TemporalTrace<T>> {
+pub fn get_recent(&self, n: usize) -> Vec<&TemporalTrace<T>> {
         self.buffer.iter().rev().take(n).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_insert_and_recent() {
+        let mut idx = TemporalIndexer::new(1, 10);
+        let trace = TemporalTrace {
+            id: uuid::Uuid::new_v4(),
+            timestamp: SystemTime::now(),
+            data: 42u32,
+            relevance: 1.0,
+            decay_factor: 1.0,
+            last_access: SystemTime::now(),
+        };
+        idx.insert(trace);
+        assert_eq!(idx.get_recent(1).len(), 1);
     }
 }

--- a/src/vision_encoder.rs
+++ b/src/vision_encoder.rs
@@ -37,3 +37,17 @@ impl VisionEncoder {
         Ok(Self::encode_image(&img))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{RgbImage, DynamicImage};
+
+    #[test]
+    fn encode_image_basic() {
+        let img = RgbImage::from_pixel(1, 1, image::Rgb([0, 0, 255]));
+        let dynimg = DynamicImage::ImageRgb8(img);
+        let emb = VisionEncoder::encode_image(&dynimg);
+        assert_eq!(emb.len(), 3);
+    }
+}

--- a/tests/integration/cli_tests.rs
+++ b/tests/integration/cli_tests.rs
@@ -1,0 +1,27 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn cli_help() {
+    Command::cargo_bin("cli").unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Minimal Memory CLI"));
+}
+
+#[test]
+fn cli_add_and_query() {
+    let path = "cli_test.jsonl";
+    let _ = std::fs::remove_file(path);
+    Command::cargo_bin("cli").unwrap()
+        .args(["--store", path, "add", "--actor", "tester", "--action", "run", "--target", "t"])
+        .assert()
+        .success();
+    let out = Command::cargo_bin("cli").unwrap()
+        .args(["--store", path, "query"])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&out.stdout).contains("tester"));
+    std::fs::remove_file(path).unwrap();
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,3 +2,5 @@ mod integration_tests;
 mod system_integration_tests;
 mod uat_tests;
 mod llm_integration_tests;
+mod test_end_to_end;
+mod cli_tests;

--- a/tests/integration/test_end_to_end.rs
+++ b/tests/integration/test_end_to_end.rs
@@ -1,0 +1,53 @@
+use hipcortex::symbolic_store::SymbolicStore;
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use hipcortex::procedural_cache::{ProceduralCache, ProceduralTrace, FSMState, FSMTransition};
+use hipcortex::aureus_bridge::AureusBridge;
+use hipcortex::llm_clients::mock::MockClient;
+use hipcortex::memory_store::MemoryStore;
+use hipcortex::snapshot_manager::SnapshotManager;
+use uuid::Uuid;
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+#[test]
+fn full_memory_flow() {
+    // symbolic node
+    let mut store = SymbolicStore::new();
+    let id = store.add_node("city", HashMap::new());
+
+    // temporal trace referencing symbolic id
+    let mut temporal = TemporalIndexer::new(4, 3600);
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: id,
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    temporal.insert(trace);
+
+    // procedural cache
+    let mut proc = ProceduralCache::new();
+    let ptrace = ProceduralTrace { id: Uuid::new_v4(), current_state: FSMState::Start, memory: HashMap::new() };
+    proc.add_trace(ptrace.clone());
+    proc.add_transition(FSMTransition { from: FSMState::Start, to: FSMState::Observe, condition: None });
+    assert_eq!(proc.advance(ptrace.id, None), Some(FSMState::Observe));
+
+    // reflexion loop and persistence
+    let mut bridge = AureusBridge::with_client(Box::new(MockClient));
+    let path = "end_to_end.jsonl";
+    let mut mem = MemoryStore::new(path).unwrap();
+    mem.clear();
+    bridge.reflexion_loop("context", &mut mem);
+    assert_eq!(mem.all().len(), 1);
+
+    // snapshot and restore
+    let archive = SnapshotManager::save(path, "e2e").unwrap();
+    mem.clear();
+    SnapshotManager::load(&archive, ".").unwrap();
+    let restored = MemoryStore::new(path).unwrap();
+    assert_eq!(restored.all().len(), 1);
+    std::fs::remove_file(path).unwrap();
+    std::fs::remove_file(archive).unwrap();
+}

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -1,1 +1,2 @@
 mod regression_tests;
+mod test_graph;

--- a/tests/property/test_graph.rs
+++ b/tests/property/test_graph.rs
@@ -1,0 +1,23 @@
+use hipcortex::symbolic_store::SymbolicStore;
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+proptest! {
+    #[test]
+    fn chain_edges_produce_neighbors(count in 1usize..5) {
+        let mut store = SymbolicStore::new();
+        let mut ids = Vec::new();
+        for i in 0..=count {
+            let id = store.add_node(&format!("n{}", i), HashMap::new());
+            if let Some(prev) = ids.last().cloned() {
+                store.add_edge(prev, id, "next");
+            }
+            ids.push(id);
+        }
+        for win in ids.windows(2) {
+            let neigh = store.neighbors(win[0], Some("next"));
+            prop_assert_eq!(neigh.len(), 1);
+            prop_assert_eq!(neigh[0].id, win[1]);
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -5,3 +5,5 @@ mod perception_adapter_tests;
 mod snapshot_manager_tests;
 mod symbolic_store_tests;
 mod vision_encoder_tests;
+mod temporal_indexer_tests;
+mod procedural_cache_tests;

--- a/tests/unit/procedural_cache_tests.rs
+++ b/tests/unit/procedural_cache_tests.rs
@@ -1,0 +1,16 @@
+use hipcortex::procedural_cache::{ProceduralCache, ProceduralTrace, FSMState, FSMTransition};
+use uuid::Uuid;
+use std::collections::HashMap;
+
+#[test]
+fn advance_transition() {
+    let mut cache = ProceduralCache::new();
+    let trace = ProceduralTrace {
+        id: Uuid::new_v4(),
+        current_state: FSMState::Start,
+        memory: HashMap::new(),
+    };
+    cache.add_trace(trace.clone());
+    cache.add_transition(FSMTransition { from: FSMState::Start, to: FSMState::Observe, condition: None });
+    assert_eq!(cache.advance(trace.id, None), Some(FSMState::Observe));
+}

--- a/tests/unit/temporal_indexer_tests.rs
+++ b/tests/unit/temporal_indexer_tests.rs
@@ -1,0 +1,18 @@
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn insert_and_get_recent() {
+    let mut indexer = TemporalIndexer::new(1, 10);
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: "test",
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+    assert_eq!(indexer.get_recent(1).len(), 1);
+}


### PR DESCRIPTION
## Summary
- cover core modules with new unit tests inside each file
- add property-based graph tests with proptest
- implement CLI and end-to-end integration tests
- scaffold Criterion benchmark for symbolic store
- provide sample memory trace fixture
- register new tests in suites

## Testing
- `cargo test --quiet`
