### PR TITLE
Add pluggable graph database for symbolic store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.21"
 zstd = "0.13"
 lazy_static = "1"
 lru = "0.12"
+sled = "0.34"
 futures = "0.3"
 bytemuck = "1"
 wasmtime = { version = "8", optional = true }
@@ -48,6 +49,7 @@ criterion = "0.5"
 assert_cmd = "2"
 predicates = "3"
 pollster = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = { version = "0.9", optional = true }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ and reasoning components.
 - **Procedural FSM Cache:** Regenerative memory driven by finite state logic for
   workflows and actions.
 - **Symbolic Store:** Graph-based concept store with semantic key/value pairs.
-  Backed by a pluggable `GraphDatabase` trait for in-memory or external graphs.
+  Backed by a pluggable `GraphDatabase` trait for in-memory or persistent graphs
+  (via the optional `SledGraph` backend).
 - **Perception Adapter:** Multimodal input handler (text, embeddings, agent
   messages, vision). Includes a simple VisionEncoder for image embeddings.
 - **Aureus Bridge:** Reflexion and reasoning hook for chain-of-thought engines.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and reasoning components.
 - **Procedural FSM Cache:** Regenerative memory driven by finite state logic for
   workflows and actions.
 - **Symbolic Store:** Graph-based concept store with semantic key/value pairs.
+  Backed by a pluggable `GraphDatabase` trait for in-memory or external graphs.
 - **Perception Adapter:** Multimodal input handler (text, embeddings, agent
   messages, vision). Includes a simple VisionEncoder for image embeddings.
 - **Aureus Bridge:** Reflexion and reasoning hook for chain-of-thought engines.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,8 @@ extended as your use case grows.
 2. **Temporal Indexer** – stores recent traces with decay logic for short or
    long‑term retention.
 3. **Symbolic Store** – maintains a graph of concepts and relationships via a
-   pluggable `GraphDatabase` backend.
+   pluggable `GraphDatabase` backend. Supports both in-memory graphs and the
+   persistent `SledGraph` implementation for durability.
 4. **Procedural Cache** – drives FSM-based workflows and regenerative actions.
 5. **Aureus Bridge** – plugs in reflexion or chain‑of‑thought reasoning loops.
 6. **Integration Layer** – exposes REST/gRPC endpoints and protocol adapters.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,8 @@ extended as your use case grows.
 1. **Perception Adapter** – normalizes text, embeddings and vision input using `VisionEncoder` into memory traces.
 2. **Temporal Indexer** – stores recent traces with decay logic for short or
    long‑term retention.
-3. **Symbolic Store** – maintains a graph of concepts and relationships.
+3. **Symbolic Store** – maintains a graph of concepts and relationships via a
+   pluggable `GraphDatabase` backend.
 4. **Procedural Cache** – drives FSM-based workflows and regenerative actions.
 5. **Aureus Bridge** – plugs in reflexion or chain‑of‑thought reasoning loops.
 6. **Integration Layer** – exposes REST/gRPC endpoints and protocol adapters.

--- a/src/modules/symbolic_store.rs
+++ b/src/modules/symbolic_store.rs
@@ -1,10 +1,11 @@
 use lru::LruCache;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use uuid::Uuid;
 
 /// Node within the symbolic graph.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicNode {
     pub id: Uuid,
     pub label: String,
@@ -12,7 +13,7 @@ pub struct SymbolicNode {
 }
 
 /// Directed edge between two nodes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SymbolicEdge {
     pub from: Uuid,
     pub to: Uuid,
@@ -23,12 +24,12 @@ pub struct SymbolicEdge {
 pub trait GraphDatabase {
     fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid;
     fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str);
-    fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode>;
-    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode>;
-    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge>;
+    fn get_node(&self, node_id: Uuid) -> Option<SymbolicNode>;
+    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicNode>;
+    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicEdge>;
     fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool;
-    fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode>;
-    fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode>;
+    fn find_by_label(&mut self, label: &str) -> Vec<SymbolicNode>;
+    fn find_by_property(&self, key: &str, value: &str) -> Vec<SymbolicNode>;
     fn remove_node(&mut self, node_id: Uuid) -> bool;
 }
 
@@ -70,22 +71,23 @@ impl GraphDatabase for InMemoryGraph {
         self.edges.insert(edge);
     }
 
-    fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode> {
-        self.nodes.get(&node_id)
+    fn get_node(&self, node_id: Uuid) -> Option<SymbolicNode> {
+        self.nodes.get(&node_id).cloned()
     }
 
-    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode> {
+    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicNode> {
         self.edges
             .iter()
             .filter(|e| e.from == node_id && relation.map_or(true, |r| r == e.relation))
-            .filter_map(|e| self.nodes.get(&e.to))
+            .filter_map(|e| self.nodes.get(&e.to).cloned())
             .collect()
     }
 
-    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge> {
+    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicEdge> {
         self.edges
             .iter()
             .filter(|e| e.from == node_id && relation.map_or(true, |r| r == e.relation))
+            .cloned()
             .collect()
     }
 
@@ -98,11 +100,11 @@ impl GraphDatabase for InMemoryGraph {
         }
     }
 
-    fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode> {
+    fn find_by_label(&mut self, label: &str) -> Vec<SymbolicNode> {
         if let Some(ids) = self.label_cache.get(label).cloned() {
             return ids
                 .into_iter()
-                .filter_map(|id| self.nodes.get(&id))
+                .filter_map(|id| self.nodes.get(&id).cloned())
                 .collect();
         }
         let ids: Vec<Uuid> = self
@@ -113,14 +115,15 @@ impl GraphDatabase for InMemoryGraph {
             .collect();
         self.label_cache.put(label.to_string(), ids.clone());
         ids.into_iter()
-            .filter_map(|id| self.nodes.get(&id))
+            .filter_map(|id| self.nodes.get(&id).cloned())
             .collect()
     }
 
-    fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode> {
+    fn find_by_property(&self, key: &str, value: &str) -> Vec<SymbolicNode> {
         self.nodes
             .values()
             .filter(|n| n.properties.get(key).map_or(false, |v| v == value))
+            .cloned()
             .collect()
     }
 
@@ -128,6 +131,130 @@ impl GraphDatabase for InMemoryGraph {
         let existed = self.nodes.remove(&node_id).is_some();
         if existed {
             self.edges.retain(|e| e.from != node_id && e.to != node_id);
+        }
+        existed
+    }
+}
+
+/// Persistent graph backend backed by a `sled` key-value store.
+pub struct SledGraph {
+    db: sled::Db,
+    nodes: sled::Tree,
+    edges: sled::Tree,
+}
+
+impl SledGraph {
+    /// Open or create a sled-backed graph at the given path.
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> sled::Result<Self> {
+        let db = sled::open(path)?;
+        let nodes = db.open_tree("nodes")?;
+        let edges = db.open_tree("edges")?;
+        Ok(Self { db, nodes, edges })
+    }
+
+    fn edge_key(from: Uuid, relation: &str, to: Uuid) -> Vec<u8> {
+        let mut key = from.as_bytes().to_vec();
+        key.extend_from_slice(relation.as_bytes());
+        key.push(0); // separator
+        key.extend_from_slice(to.as_bytes());
+        key
+    }
+}
+
+impl GraphDatabase for SledGraph {
+    fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid {
+        let id = Uuid::new_v4();
+        let node = SymbolicNode {
+            id,
+            label: label.to_string(),
+            properties,
+        };
+        let data = serde_json::to_vec(&node).unwrap();
+        self.nodes.insert(id.as_bytes(), data).unwrap();
+        id
+    }
+
+    fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str) {
+        let edge = SymbolicEdge {
+            from,
+            to,
+            relation: relation.to_string(),
+        };
+        let key = Self::edge_key(from, relation, to);
+        let data = serde_json::to_vec(&edge).unwrap();
+        self.edges.insert(key, data).unwrap();
+    }
+
+    fn get_node(&self, node_id: Uuid) -> Option<SymbolicNode> {
+        self.nodes
+            .get(node_id.as_bytes())
+            .ok()
+            .flatten()
+            .and_then(|v| serde_json::from_slice(&v).ok())
+    }
+
+    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicNode> {
+        let prefix = node_id.as_bytes();
+        self.edges
+            .scan_prefix(prefix)
+            .filter_map(|res| res.ok())
+            .filter_map(|(_, v)| serde_json::from_slice::<SymbolicEdge>(&v).ok())
+            .filter(|e| relation.map_or(true, |r| r == e.relation))
+            .filter_map(|e| self.get_node(e.to))
+            .collect()
+    }
+
+    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicEdge> {
+        let prefix = node_id.as_bytes();
+        self.edges
+            .scan_prefix(prefix)
+            .filter_map(|res| res.ok())
+            .filter_map(|(_, v)| serde_json::from_slice::<SymbolicEdge>(&v).ok())
+            .filter(|e| relation.map_or(true, |r| r == e.relation))
+            .collect()
+    }
+
+    fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool {
+        if let Some(mut node) = self.get_node(node_id) {
+            node.properties.insert(key.to_string(), value.to_string());
+            let data = serde_json::to_vec(&node).unwrap();
+            self.nodes.insert(node_id.as_bytes(), data).unwrap();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn find_by_label(&mut self, label: &str) -> Vec<SymbolicNode> {
+        self.nodes
+            .iter()
+            .filter_map(|res| res.ok())
+            .filter_map(|(_, v)| serde_json::from_slice::<SymbolicNode>(&v).ok())
+            .filter(|n| n.label == label)
+            .collect()
+    }
+
+    fn find_by_property(&self, key: &str, value: &str) -> Vec<SymbolicNode> {
+        self.nodes
+            .iter()
+            .filter_map(|res| res.ok())
+            .filter_map(|(_, v)| serde_json::from_slice::<SymbolicNode>(&v).ok())
+            .filter(|n| n.properties.get(key).map_or(false, |v| v == value))
+            .collect()
+    }
+
+    fn remove_node(&mut self, node_id: Uuid) -> bool {
+        let existed = self.nodes.remove(node_id.as_bytes()).unwrap().is_some();
+        if existed {
+            let prefix = node_id.as_bytes().to_vec();
+            let edges: Vec<Vec<u8>> = self
+                .edges
+                .scan_prefix(&prefix)
+                .filter_map(|res| res.ok().map(|(k, _)| k.to_vec()))
+                .collect();
+            for k in edges {
+                self.edges.remove(k).unwrap();
+            }
         }
         existed
     }
@@ -161,15 +288,15 @@ impl<B: GraphDatabase> SymbolicStore<B> {
         self.backend.add_edge(from, to, relation)
     }
 
-    pub fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode> {
+    pub fn get_node(&self, node_id: Uuid) -> Option<SymbolicNode> {
         self.backend.get_node(node_id)
     }
 
-    pub fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode> {
+    pub fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicNode> {
         self.backend.neighbors(node_id, relation)
     }
 
-    pub fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge> {
+    pub fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<SymbolicEdge> {
         self.backend.edges_from(node_id, relation)
     }
 
@@ -177,11 +304,11 @@ impl<B: GraphDatabase> SymbolicStore<B> {
         self.backend.update_property(node_id, key, value)
     }
 
-    pub fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode> {
+    pub fn find_by_label(&mut self, label: &str) -> Vec<SymbolicNode> {
         self.backend.find_by_label(label)
     }
 
-    pub fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode> {
+    pub fn find_by_property(&self, key: &str, value: &str) -> Vec<SymbolicNode> {
         self.backend.find_by_property(key, value)
     }
 

--- a/src/modules/symbolic_store.rs
+++ b/src/modules/symbolic_store.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use uuid::Uuid;
 
+/// Node within the symbolic graph.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SymbolicNode {
     pub id: Uuid,
@@ -10,6 +11,7 @@ pub struct SymbolicNode {
     pub properties: HashMap<String, String>,
 }
 
+/// Directed edge between two nodes.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SymbolicEdge {
     pub from: Uuid,
@@ -17,13 +19,27 @@ pub struct SymbolicEdge {
     pub relation: String,
 }
 
-pub struct SymbolicStore {
-    pub nodes: HashMap<Uuid, SymbolicNode>,
-    pub edges: HashSet<SymbolicEdge>,
+/// Abstraction over a graph database used by `SymbolicStore`.
+pub trait GraphDatabase {
+    fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid;
+    fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str);
+    fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode>;
+    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode>;
+    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge>;
+    fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool;
+    fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode>;
+    fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode>;
+    fn remove_node(&mut self, node_id: Uuid) -> bool;
+}
+
+/// Simple in-memory graph backend with an LRU cache for label lookups.
+pub struct InMemoryGraph {
+    nodes: HashMap<Uuid, SymbolicNode>,
+    edges: HashSet<SymbolicEdge>,
     label_cache: LruCache<String, Vec<Uuid>>,
 }
 
-impl SymbolicStore {
+impl InMemoryGraph {
     pub fn new() -> Self {
         Self {
             nodes: HashMap::new(),
@@ -31,8 +47,10 @@ impl SymbolicStore {
             label_cache: LruCache::new(NonZeroUsize::new(32).unwrap()),
         }
     }
+}
 
-    pub fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid {
+impl GraphDatabase for InMemoryGraph {
+    fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid {
         let node = SymbolicNode {
             id: Uuid::new_v4(),
             label: label.to_string(),
@@ -43,7 +61,7 @@ impl SymbolicStore {
         node_id
     }
 
-    pub fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str) {
+    fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str) {
         let edge = SymbolicEdge {
             from,
             to,
@@ -52,11 +70,11 @@ impl SymbolicStore {
         self.edges.insert(edge);
     }
 
-    pub fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode> {
+    fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode> {
         self.nodes.get(&node_id)
     }
 
-    pub fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode> {
+    fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode> {
         self.edges
             .iter()
             .filter(|e| e.from == node_id && relation.map_or(true, |r| r == e.relation))
@@ -64,14 +82,14 @@ impl SymbolicStore {
             .collect()
     }
 
-    pub fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge> {
+    fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge> {
         self.edges
             .iter()
             .filter(|e| e.from == node_id && relation.map_or(true, |r| r == e.relation))
             .collect()
     }
 
-    pub fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool {
+    fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool {
         if let Some(node) = self.nodes.get_mut(&node_id) {
             node.properties.insert(key.to_string(), value.to_string());
             true
@@ -80,7 +98,7 @@ impl SymbolicStore {
         }
     }
 
-    pub fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode> {
+    fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode> {
         if let Some(ids) = self.label_cache.get(label).cloned() {
             return ids
                 .into_iter()
@@ -99,19 +117,84 @@ impl SymbolicStore {
             .collect()
     }
 
-    pub fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode> {
+    fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode> {
         self.nodes
             .values()
             .filter(|n| n.properties.get(key).map_or(false, |v| v == value))
             .collect()
     }
 
-    pub fn remove_node(&mut self, node_id: Uuid) -> bool {
+    fn remove_node(&mut self, node_id: Uuid) -> bool {
         let existed = self.nodes.remove(&node_id).is_some();
         if existed {
             self.edges.retain(|e| e.from != node_id && e.to != node_id);
         }
         existed
+    }
+}
+
+/// High level store that delegates operations to a chosen backend.
+pub struct SymbolicStore<B: GraphDatabase> {
+    backend: B,
+}
+
+impl SymbolicStore<InMemoryGraph> {
+    /// Create a new store using the default in-memory backend.
+    pub fn new() -> Self {
+        Self {
+            backend: InMemoryGraph::new(),
+        }
+    }
+}
+
+impl<B: GraphDatabase> SymbolicStore<B> {
+    /// Instantiate a store with a custom graph backend.
+    pub fn from_backend(backend: B) -> Self {
+        Self { backend }
+    }
+
+    pub fn add_node(&mut self, label: &str, properties: HashMap<String, String>) -> Uuid {
+        self.backend.add_node(label, properties)
+    }
+
+    pub fn add_edge(&mut self, from: Uuid, to: Uuid, relation: &str) {
+        self.backend.add_edge(from, to, relation)
+    }
+
+    pub fn get_node(&self, node_id: Uuid) -> Option<&SymbolicNode> {
+        self.backend.get_node(node_id)
+    }
+
+    pub fn neighbors(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicNode> {
+        self.backend.neighbors(node_id, relation)
+    }
+
+    pub fn edges_from(&self, node_id: Uuid, relation: Option<&str>) -> Vec<&SymbolicEdge> {
+        self.backend.edges_from(node_id, relation)
+    }
+
+    pub fn update_property(&mut self, node_id: Uuid, key: &str, value: &str) -> bool {
+        self.backend.update_property(node_id, key, value)
+    }
+
+    pub fn find_by_label(&mut self, label: &str) -> Vec<&SymbolicNode> {
+        self.backend.find_by_label(label)
+    }
+
+    pub fn find_by_property(&self, key: &str, value: &str) -> Vec<&SymbolicNode> {
+        self.backend.find_by_property(key, value)
+    }
+
+    pub fn remove_node(&mut self, node_id: Uuid) -> bool {
+        self.backend.remove_node(node_id)
+    }
+
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    pub fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
     }
 }
 

--- a/tests/unit/sled_graph_tests.rs
+++ b/tests/unit/sled_graph_tests.rs
@@ -1,0 +1,23 @@
+use hipcortex::symbolic_store::{SledGraph, SymbolicStore};
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+#[test]
+fn sled_backend_basic_ops() {
+    let dir = tempdir().unwrap();
+    let graph = SledGraph::open(dir.path()).unwrap();
+    let mut store = SymbolicStore::from_backend(graph);
+
+    let a = store.add_node("A", HashMap::new());
+    let b = store.add_node("B", HashMap::new());
+    store.add_edge(a, b, "rel");
+
+    assert_eq!(store.neighbors(a, Some("rel")).len(), 1);
+
+    // reload from disk
+    drop(store);
+    let graph = SledGraph::open(dir.path()).unwrap();
+    let mut store = SymbolicStore::from_backend(graph);
+    let neighbors = store.neighbors(a, Some("rel"));
+    assert_eq!(neighbors.len(), 1);
+}


### PR DESCRIPTION
## Summary
- introduce `GraphDatabase` trait and `InMemoryGraph` backend
- refactor `SymbolicStore` to use pluggable graph backend
- document new backend design in README and architecture docs

## Testing
- `cargo test --quiet`
