### PR TITLE
Update docs with collapse-resilience modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ and reasoning components.
 - **Optional Web Server:** compile with `--features web-server` for an Axum REST API.
 - **Optional GUI:** compile with `--features gui` to launch a Tauri desktop client.
 - **RocksDB Backend:** use `MemoryStore::new_rocksdb` for an embedded key-value database.
+- **Effort Evaluator & Confidence Regulator (planned):** track reasoning fatigue and decay to prevent collapse.
+- **Hypothesis Manager (planned):** maintain multiple reasoning paths and a quantized state tree for backtracking.
+- **Puzzle Benchmark Suite (planned):** validates complex planning algorithms like Tower of Hanoi and 8-puzzle.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,3 +109,6 @@ Additional modules extend HipCortex further:
 - **Secure LLM Sandbox**: `sandbox::SecureLLMSandbox` renders templates with whitelisted variables before sending to LLMs.
 - **World Model Dashboard**: when the `web-server` feature is enabled, `dashboard::routes` exposes memory data for a lightweight web UI.
 - **gRPC Server**: enabling the `grpc-server` feature spins up a Tonic-based service for adding and listing memory records.
+- **Effort Evaluator & Confidence Regulator (planned)**: measure reasoning effort and confidence decay to avoid collapse.
+- **Hypothesis Manager (planned)**: maintain multiple reasoning branches and a quantized state tree for backtracking.
+- **Puzzle Benchmark Suite (planned)**: verifies complex planning algorithms to gauge collapse resilience.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,10 @@
 - Real-time agentic CLI and Web UI
 - Expanded open-source LLM connectors (Llama, DeepSeek, etc.)
 - Local inference via Ollama or custom backends
+- EffortEvaluator & ConfidenceRegulator for collapse resistance metrics
+- HypothesisManager and quantized state tree for multi-path reasoning
+- Procedural backtracking and fallback logic
+- Puzzle benchmark harness for algorithmic planning tasks
 
 ## Roadmap Highlights
 - **Vision encoder**: Integrate image/embedding modules for visual reasoning.
@@ -26,6 +30,8 @@
 - **RAG/Notion export**: Connect to retrieval backends and Notion for knowledge sync.
 - **World model memory**: Store agent/environment state and simulate context.
 - **Real-time CLI/Web**: Manage, debug, and visualize agentic memory interactively.
+- **Collapse metrics**: EffortEvaluator and ConfidenceRegulator measure reasoning fatigue and collapse_score.
+- **Puzzle benchmark suite**: Validate complex planning tasks like Tower of Hanoi for regression testing.
 
 ---
 


### PR DESCRIPTION
## Summary
- document planned EffortEvaluator, HypothesisManager and puzzle benchmarks
- list new modules in architecture description
- expand roadmap with collapse metrics and puzzle harness

## Testing
- `cargo test`
