### PR TITLE
Make RocksDB optional to avoid build timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ lru = "0.12"
 sled = "0.34"
 futures = "0.3"
 bytemuck = "1"
-rocksdb = "0.21"
+rocksdb = { version = "0.21", optional = true }
 wasmtime = { version = "8", optional = true }
 wat = { version = "1", optional = true }
 mustache = "0.9"
@@ -72,3 +72,5 @@ async-store = ["tokio", "async-trait"]
 parallel = ["rayon"]
 gpu = ["wgpu"]
 grpc-server = ["tonic", "prost", "tokio", "tonic-build"]
+rocksdb-backend = ["rocksdb"]
+default = []

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and reasoning components.
 - **Fully Test-Driven:** Extensive unit tests and Criterion benchmarks.
 - **Optional Web Server:** compile with `--features web-server` for an Axum REST API.
 - **Optional GUI:** compile with `--features gui` to launch a Tauri desktop client.
-- **RocksDB Backend:** use `MemoryStore::new_rocksdb` for an embedded key-value database.
+- **RocksDB Backend:** compile with `--features rocksdb-backend` and use `MemoryStore::new_rocksdb` for an embedded key-value database.
 - **Effort Evaluator & Confidence Regulator (planned):** track reasoning fatigue and decay to prevent collapse.
 - **Hypothesis Manager (planned):** maintain multiple reasoning paths and a quantized state tree for backtracking.
 - **Puzzle Benchmark Suite (planned):** validates complex planning algorithms like Tower of Hanoi and 8-puzzle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod persistence;
 pub mod plugin_host;
 #[path = "modules/procedural_cache.rs"]
 pub mod procedural_cache;
+#[cfg(feature = "rocksdb-backend")]
 pub mod rocksdb_backend;
 pub mod sandbox;
 pub mod schema;

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use crate::audit_log::AuditLog;
 use crate::memory_record::MemoryRecord;
 use crate::persistence::{FileBackend, MemoryBackend};
+#[cfg(feature = "rocksdb-backend")]
 use crate::rocksdb_backend::RocksDbBackend;
 use anyhow::Result;
 
@@ -89,6 +90,7 @@ impl MemoryStore<FileBackend> {
     }
 }
 
+#[cfg(feature = "rocksdb-backend")]
 impl MemoryStore<RocksDbBackend> {
     pub fn new_rocksdb<P: AsRef<Path>>(path: P, batch: usize) -> Result<Self> {
         let backend = RocksDbBackend::new(&path)?;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,6 +3,7 @@ mod cli_tests;
 mod grpc_tests;
 mod integration_tests;
 mod llm_integration_tests;
+mod reasoning_trace_sit_tests;
 mod system_integration_tests;
 mod test_end_to_end;
 mod uat_tests;

--- a/tests/integration/reasoning_trace_sit_tests.rs
+++ b/tests/integration/reasoning_trace_sit_tests.rs
@@ -1,0 +1,29 @@
+use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn store_reasoning_trace_via_adapter_and_indexer() {
+    let mut indexer = TemporalIndexer::new(2, 3600);
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some("remember me".to_string()),
+        embedding: None,
+        image_data: None,
+        tags: vec!["sit".into()],
+    };
+    PerceptionAdapter::adapt(input.clone());
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: input.text.unwrap(),
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+    let recent = indexer.get_recent(1);
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].data, "remember me");
+}

--- a/tests/integration/uat_tests.rs
+++ b/tests/integration/uat_tests.rs
@@ -38,3 +38,32 @@ fn athena_reflexion_placeholder() {
     store.clear();
     aureus.reflexion_loop("ctx", &mut store);
 }
+
+#[test]
+fn user_store_reasoning_trace() {
+    use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some("UAT reasoning".to_string()),
+        embedding: None,
+        image_data: None,
+        tags: vec!["uat".into()],
+    };
+    PerceptionAdapter::adapt(input.clone());
+
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: input.text.unwrap(),
+        relevance: 1.0,
+        decay_factor: 0.5,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+
+    let last_trace = indexer.get_recent(1)[0];
+    assert_eq!(last_trace.data, "UAT reasoning");
+}

--- a/tests/test_report/SITTestReport.md
+++ b/tests/test_report/SITTestReport.md
@@ -6,5 +6,6 @@ This report summarizes the system integration tests validating interactions acro
 
 - **memory_round_trip:** inserts a symbolic node, stores it in temporal memory, adapts a perception input, and verifies retrieval.
 - **integration_and_reflexion:** initializes the IntegrationLayer and AureusBridge together without errors.
+- **store_reasoning_trace_via_adapter_and_indexer:** validates storing a text percept as a temporal trace.
 
 All system integration tests pass, confirming basic cross-module functionality.

--- a/tests/test_report/UATTestReport.md
+++ b/tests/test_report/UATTestReport.md
@@ -6,5 +6,6 @@ These tests validate end user workflows using the memory engine.
 
 - **travelg3n_store_and_retrieve_city:** simulates storing a city and retrieving it via temporal memory.
 - **athena_reflexion_placeholder:** ensures the reflexion loop runs without panic.
+- **user_store_reasoning_trace:** captures a user message and persists it in temporal memory.
 
 Both user acceptance tests pass, demonstrating typical user scenarios complete successfully.

--- a/tests/test_report/UnitTestReport.md
+++ b/tests/test_report/UnitTestReport.md
@@ -65,8 +65,12 @@ This report summarizes the unit tests implemented and passed for the HipCortex M
   Tests that the reflexion loop can be started.
 - **Multiple reflexion loops:**
   Ensures that calling the reflexion loop multiple times is safe.
-- **Loop counter reset:**
-  Verifies loop counting and reset functionality.
+ - **Loop counter reset:**
+   Verifies loop counting and reset functionality.
+
+## 7. Reasoning trace store (in `reasoning_trace_store_tests.rs`)
+- **Store trace after perception:**
+  Confirms that adapting a percept and inserting it into the TemporalIndexer retains the trace.
 
 ---
 

--- a/tests/unit/memory_store_tests.rs
+++ b/tests/unit/memory_store_tests.rs
@@ -153,6 +153,7 @@ fn test_envelope_encryption() {
     fs::remove_file("test_memory_env.sk").unwrap();
 }
 
+#[cfg(feature = "rocksdb-backend")]
 #[test]
 #[ignore]
 fn test_rocksdb_backend() {

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -7,6 +7,7 @@ mod memory_store_tests;
 mod perception_adapter_tests;
 mod plugin_host_tests;
 mod procedural_cache_tests;
+mod reasoning_trace_store_tests;
 mod snapshot_manager_tests;
 mod symbolic_store_tests;
 mod temporal_indexer_tests;

--- a/tests/unit/reasoning_trace_store_tests.rs
+++ b/tests/unit/reasoning_trace_store_tests.rs
@@ -1,0 +1,27 @@
+use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn store_trace_after_perception() {
+    let mut indexer = TemporalIndexer::new(4, 3600);
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some("trace".to_string()),
+        embedding: None,
+        image_data: None,
+        tags: vec!["unit".to_string()],
+    };
+    PerceptionAdapter::adapt(input.clone());
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: input.text.unwrap(),
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+    assert_eq!(indexer.get_recent(1).len(), 1);
+}


### PR DESCRIPTION
## Summary
- turn `rocksdb` crate into an optional dependency
- gate RocksDB-related code and tests behind a new `rocksdb-backend` feature
- document the feature in the README

## Testing
- `cargo test --no-default-features --quiet`
