### PR TITLE
Add query tests for SymbolicStore

### DIFF
--- a/tests/integration/system_integration_tests.rs
+++ b/tests/integration/system_integration_tests.rs
@@ -46,3 +46,27 @@ fn integration_and_reflexion() {
     store.clear();
     aureus.reflexion_loop("ctx", &mut store);
 }
+
+#[test]
+fn query_symbol_via_indexer() {
+    let mut store = SymbolicStore::new();
+    let mut indexer = TemporalIndexer::new(2, 3600);
+    let mut props = HashMap::new();
+    props.insert("kind".to_string(), "planet".to_string());
+    let node_id = store.add_node("Mars", props.clone());
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: node_id,
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+    let recent = indexer.get_recent(1)[0].data;
+    let node = store.get_node(recent).unwrap();
+    assert_eq!(node.label, "Mars");
+    let by_prop = store.find_by_property("kind", "planet");
+    assert_eq!(by_prop.len(), 1);
+    assert_eq!(by_prop[0].id, node_id);
+}

--- a/tests/integration/uat_tests.rs
+++ b/tests/integration/uat_tests.rs
@@ -67,3 +67,14 @@ fn user_store_reasoning_trace() {
     let last_trace = indexer.get_recent(1)[0];
     assert_eq!(last_trace.data, "UAT reasoning");
 }
+
+#[test]
+fn user_query_city_by_label() {
+    let mut store = SymbolicStore::new();
+    let mut props = HashMap::new();
+    props.insert("type".to_string(), "city".to_string());
+    store.add_node("London", props.clone());
+    let results = store.find_by_label("London");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].properties.get("type").unwrap(), "city");
+}

--- a/tests/test_report/SITTestReport.md
+++ b/tests/test_report/SITTestReport.md
@@ -7,5 +7,6 @@ This report summarizes the system integration tests validating interactions acro
 - **memory_round_trip:** inserts a symbolic node, stores it in temporal memory, adapts a perception input, and verifies retrieval.
 - **integration_and_reflexion:** initializes the IntegrationLayer and AureusBridge together without errors.
 - **store_reasoning_trace_via_adapter_and_indexer:** validates storing a text percept as a temporal trace.
+- **query_symbol_via_indexer:** verifies querying nodes via label and property after retrieval from TemporalIndexer.
 
 All system integration tests pass, confirming basic cross-module functionality.

--- a/tests/test_report/UATTestReport.md
+++ b/tests/test_report/UATTestReport.md
@@ -7,5 +7,6 @@ These tests validate end user workflows using the memory engine.
 - **travelg3n_store_and_retrieve_city:** simulates storing a city and retrieving it via temporal memory.
 - **athena_reflexion_placeholder:** ensures the reflexion loop runs without panic.
 - **user_store_reasoning_trace:** captures a user message and persists it in temporal memory.
+- **user_query_city_by_label:** ensures cities can be retrieved by label for end-user exploration.
 
-Both user acceptance tests pass, demonstrating typical user scenarios complete successfully.
+All user acceptance tests pass, demonstrating typical user scenarios complete successfully.

--- a/tests/test_report/UnitTestReport.md
+++ b/tests/test_report/UnitTestReport.md
@@ -37,6 +37,8 @@ This report summarizes the unit tests implemented and passed for the HipCortex M
   Confirms that adding nodes with the same label creates unique nodes.
 - **Edges from query:**
   Tests retrieving outgoing edges for a node.
+- **Query by label and property:**
+  Verifies retrieving nodes via label and property filters.
 
 ## 4. PerceptionAdapter (in `perception_adapter_tests.rs`)
 - **Adapt text input:**

--- a/tests/unit/symbolic_store_tests.rs
+++ b/tests/unit/symbolic_store_tests.rs
@@ -80,3 +80,17 @@ fn edges_from_query() {
     let edges = store.edges_from(a, Some("rel"));
     assert_eq!(edges.len(), 2);
 }
+
+#[test]
+fn query_by_label_and_property() {
+    let mut store = SymbolicStore::new();
+    let mut props = HashMap::new();
+    props.insert("category".to_string(), "tool".to_string());
+    let node_id = store.add_node("Hammer", props.clone());
+    let by_label = store.find_by_label("Hammer");
+    assert_eq!(by_label.len(), 1);
+    assert_eq!(by_label[0].id, node_id);
+    let by_prop = store.find_by_property("category", "tool");
+    assert_eq!(by_prop.len(), 1);
+    assert_eq!(by_prop[0].id, node_id);
+}


### PR DESCRIPTION
## Summary
- add new query test to unit `symbolic_store_tests`
- exercise SymbolicStore queries in system integration tests
- cover user-level lookup in UAT tests
- document new tests in test reports

## Testing
- `cargo test`