### PR TITLE
Add world model graph export and tests

### DIFF
--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -6,7 +6,7 @@ use crate::persistence::MemoryBackend;
 use axum::{routing::get, Json, Router};
 
 #[cfg(feature = "web-server")]
-pub fn routes<B: MemoryBackend + 'static>(
+pub fn routes<B: MemoryBackend + Send + 'static>(
     store: std::sync::Arc<std::sync::Mutex<MemoryStore<B>>>,
 ) -> Router {
     Router::new().route(
@@ -33,6 +33,6 @@ mod tests {
         let store = MemoryStore::new(path).unwrap();
         let arc = std::sync::Arc::new(std::sync::Mutex::new(store));
         let _app = routes(arc);
-        std::fs::remove_file(path).unwrap();
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/memory_cli.rs
+++ b/src/memory_cli.rs
@@ -50,6 +50,11 @@ enum Commands {
     Restore { tag: String },
     /// Send a prompt to OpenAI and store reflexion
     Prompt { prompt: String },
+    /// Export symbolic world model as JSON
+    Graph {
+        #[arg(long, default_value = "graph.db")]
+        db: String,
+    },
 }
 
 pub fn run() -> Result<()> {
@@ -124,6 +129,13 @@ pub fn run() -> Result<()> {
             );
             store.add(record)?;
             println!("{}", response);
+        }
+        Commands::Graph { db } => {
+            use crate::symbolic_store::{SledGraph, SymbolicStore};
+            let backend = SledGraph::open(db)?;
+            let store = SymbolicStore::from_backend(backend);
+            let graph = store.export_graph();
+            println!("{}", serde_json::to_string(&graph)?);
         }
     }
     Ok(())

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -1,11 +1,34 @@
 #[cfg(feature = "web-server")]
-use axum::{routing::get, Router};
+use axum::{routing::get, Json, Router};
 #[cfg(feature = "web-server")]
 use std::net::SocketAddr;
+#[cfg(feature = "web-server")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "web-server")]
+use crate::symbolic_store::{InMemoryGraph, SymbolicStore};
 
 #[cfg(feature = "web-server")]
 pub async fn run(addr: SocketAddr) {
-    let app = Router::new().route("/health", get(|| async { "ok" }));
+    let store = Arc::new(Mutex::new(SymbolicStore::new()));
+    run_with_store(addr, store).await;
+}
+
+#[cfg(feature = "web-server")]
+pub async fn run_with_store(
+    addr: SocketAddr,
+    store: Arc<Mutex<SymbolicStore<InMemoryGraph>>>,
+) {
+    let graph_route = {
+        let store = store.clone();
+        get(move || async move {
+            let store = store.lock().unwrap();
+            let graph = store.export_graph();
+            Json(graph)
+        })
+    };
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/graph", graph_route);
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,5 +5,7 @@ mod integration_tests;
 mod llm_integration_tests;
 mod reasoning_trace_sit_tests;
 mod system_integration_tests;
+mod world_model_cli_sit;
+mod world_model_uat;
 mod test_end_to_end;
 mod uat_tests;

--- a/tests/integration/world_model_cli_sit.rs
+++ b/tests/integration/world_model_cli_sit.rs
@@ -1,0 +1,25 @@
+use assert_cmd::Command;
+use hipcortex::symbolic_store::{SledGraph, SymbolicStore, SymbolicNode, SymbolicEdge};
+use tempfile::TempDir;
+use std::collections::HashMap;
+
+#[test]
+fn cli_exports_graph() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("graph.db");
+    {
+        let backend = SledGraph::open(&db_path).unwrap();
+        let mut store = SymbolicStore::from_backend(backend);
+        let a = store.add_node("A", HashMap::new());
+        let b = store.add_node("B", HashMap::new());
+        store.add_edge(a, b, "rel");
+    }
+    let out = Command::cargo_bin("cli")
+        .unwrap()
+        .args(["graph", "--db", db_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let parsed: (Vec<SymbolicNode>, Vec<SymbolicEdge>) = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(parsed.0.len(), 2);
+    assert_eq!(parsed.1.len(), 1);
+}

--- a/tests/integration/world_model_uat.rs
+++ b/tests/integration/world_model_uat.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "web-server")]
+use hipcortex::web_server::run_with_store;
+#[cfg(feature = "web-server")]
+use hipcortex::symbolic_store::{InMemoryGraph, SymbolicStore, SymbolicNode, SymbolicEdge};
+#[cfg(feature = "web-server")]
+use std::collections::HashMap;
+#[cfg(feature = "web-server")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "web-server")]
+use tokio::time::{sleep, Duration};
+
+#[cfg(feature = "web-server")]
+#[tokio::test]
+async fn web_server_graph_endpoint() {
+    let store = Arc::new(Mutex::new(SymbolicStore::<InMemoryGraph>::new()));
+    {
+        let mut s = store.lock().unwrap();
+        let a = s.add_node("A", HashMap::new());
+        let b = s.add_node("B", HashMap::new());
+        s.add_edge(a, b, "rel");
+    }
+    let addr: std::net::SocketAddr = "127.0.0.1:3010".parse().unwrap();
+    let srv_store = store.clone();
+    let server = tokio::spawn(async move {
+        run_with_store(addr, srv_store).await;
+    });
+    sleep(Duration::from_millis(100)).await;
+    let resp = reqwest::get("http://127.0.0.1:3010/graph").await.unwrap();
+    let text = resp.text().await.unwrap();
+    let parsed: (Vec<SymbolicNode>, Vec<SymbolicEdge>) = serde_json::from_str(&text).unwrap();
+    assert_eq!(parsed.0.len(), 2);
+    assert_eq!(parsed.1.len(), 1);
+    server.abort();
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -12,3 +12,4 @@ mod snapshot_manager_tests;
 mod symbolic_store_tests;
 mod temporal_indexer_tests;
 mod vision_encoder_tests;
+mod world_model_export_tests;

--- a/tests/unit/world_model_export_tests.rs
+++ b/tests/unit/world_model_export_tests.rs
@@ -1,0 +1,13 @@
+use hipcortex::symbolic_store::SymbolicStore;
+use std::collections::HashMap;
+
+#[test]
+fn export_graph_returns_nodes_and_edges() {
+    let mut store = SymbolicStore::new();
+    let a = store.add_node("A", HashMap::new());
+    let b = store.add_node("B", HashMap::new());
+    store.add_edge(a, b, "rel");
+    let (nodes, edges) = store.export_graph();
+    assert_eq!(nodes.len(), 2);
+    assert_eq!(edges.len(), 1);
+}


### PR DESCRIPTION
## Summary
- extend `GraphDatabase` with graph export functions
- expose graph export in `SymbolicStore`
- add `graph` subcommand to CLI
- serve `/graph` from `web_server`
- add unit, SIT and UAT tests for graph export

## Testing
- `cargo test`
- `cargo test --features web-server`
