### PR TITLE
Add conversation memory module with tests

### DIFF
--- a/src/conversation_memory.rs
+++ b/src/conversation_memory.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationMessage {
+    pub id: Uuid,
+    pub sender: String,
+    pub text: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenManusMessage {
+    pub role: String,
+    pub content: String,
+}
+
+pub struct ConversationMemory {
+    messages: Vec<ConversationMessage>,
+}
+
+impl ConversationMemory {
+    pub fn new() -> Self {
+        Self { messages: Vec::new() }
+    }
+
+    pub fn add_message(&mut self, sender: &str, text: &str) -> Uuid {
+        let msg = ConversationMessage {
+            id: Uuid::new_v4(),
+            sender: sender.to_string(),
+            text: text.to_string(),
+            timestamp: Utc::now(),
+        };
+        self.messages.push(msg.clone());
+        msg.id
+    }
+
+    pub fn ingest_openmanus(&mut self, json: &str) -> Result<Uuid> {
+        let m: OpenManusMessage = serde_json::from_str(json)?;
+        Ok(self.add_message(&m.role, &m.content))
+    }
+
+    pub fn messages(&self) -> &[ConversationMessage] {
+        &self.messages
+    }
+
+    pub fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.messages.clear();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod gui;
 pub mod integration_layer;
 pub mod llm_clients;
 pub mod memory;
+pub mod conversation_memory;
 pub mod memory_cli;
 pub mod memory_diff;
 pub mod memory_processor;

--- a/tests/integration/conversation_memory_sit.rs
+++ b/tests/integration/conversation_memory_sit.rs
@@ -1,0 +1,25 @@
+use hipcortex::conversation_memory::ConversationMemory;
+use hipcortex::memory_record::{MemoryRecord, MemoryType};
+use hipcortex::memory_store::MemoryStore;
+
+#[test]
+fn openmanus_round_trip_into_store() {
+    let mut conv = ConversationMemory::new();
+    conv.add_message("user", "hello");
+    conv.add_message("assistant", "hi there");
+    let path = "test_conv_store.jsonl";
+    let _ = std::fs::remove_file(path);
+    let mut store = MemoryStore::new(path).unwrap();
+    for msg in conv.messages() {
+        let rec = MemoryRecord::new(
+            MemoryType::Symbolic,
+            msg.sender.clone(),
+            "says".into(),
+            msg.text.clone(),
+            serde_json::json!({}),
+        );
+        store.add(rec).unwrap();
+    }
+    assert_eq!(store.all().len(), 2);
+    std::fs::remove_file(path).unwrap();
+}

--- a/tests/integration/conversation_memory_uat.rs
+++ b/tests/integration/conversation_memory_uat.rs
@@ -1,0 +1,15 @@
+use hipcortex::conversation_memory::ConversationMemory;
+use hipcortex::integration_layer::IntegrationLayer;
+
+#[test]
+fn user_flow_conversation_memory() {
+    let mut layer = IntegrationLayer::new();
+    layer.connect();
+    layer.add_api_key("k".into());
+    let mut conv = ConversationMemory::new();
+    conv.add_message("user", "Hello");
+    conv.add_message("assistant", "Hi!");
+    assert_eq!(conv.len(), 2);
+    layer.send_message("k", "conversation complete");
+    assert!(layer.is_connected());
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -7,5 +7,7 @@ mod reasoning_trace_sit_tests;
 mod system_integration_tests;
 mod world_model_cli_sit;
 mod world_model_uat;
+mod conversation_memory_sit;
+mod conversation_memory_uat;
 mod test_end_to_end;
 mod uat_tests;

--- a/tests/unit/conversation_memory_tests.rs
+++ b/tests/unit/conversation_memory_tests.rs
@@ -1,0 +1,18 @@
+use hipcortex::conversation_memory::ConversationMemory;
+
+#[test]
+fn add_and_len() {
+    let mut cm = ConversationMemory::new();
+    cm.add_message("user", "hello");
+    assert_eq!(cm.len(), 1);
+    assert_eq!(cm.messages()[0].text, "hello");
+}
+
+#[test]
+fn ingest_openmanus_json() {
+    let mut cm = ConversationMemory::new();
+    let json = r#"{"role":"assistant","content":"hi"}"#;
+    cm.ingest_openmanus(json).unwrap();
+    assert_eq!(cm.len(), 1);
+    assert_eq!(cm.messages()[0].sender, "assistant");
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -13,3 +13,4 @@ mod symbolic_store_tests;
 mod temporal_indexer_tests;
 mod vision_encoder_tests;
 mod world_model_export_tests;
+mod conversation_memory_tests;


### PR DESCRIPTION
## Summary
- implement `conversation_memory` module supporting OpenManus-style messages
- expose module from `lib.rs`
- add unit tests for conversation memory
- add SIT and UAT tests integrating conversation memory with memory store and integration layer

## Testing
- `cargo test`
