### PR TITLE
Add retrieval pipeline tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod snapshot_manager;
 pub mod symbolic_store;
 #[path = "modules/temporal_indexer.rs"]
 pub mod temporal_indexer;
+pub mod retrieval_pipeline;
 #[cfg(feature = "async-store")]
 pub use persistence::{AsyncFileBackend, AsyncMemoryBackend};
 #[cfg(feature = "grpc-server")]

--- a/src/retrieval_pipeline.rs
+++ b/src/retrieval_pipeline.rs
@@ -1,0 +1,16 @@
+use crate::symbolic_store::{GraphDatabase, SymbolicNode, SymbolicStore};
+use crate::temporal_indexer::TemporalIndexer;
+use uuid::Uuid;
+
+/// Retrieve the most recent symbolic nodes referenced by the temporal indexer.
+pub fn recent_symbols<B: GraphDatabase>(
+    store: &SymbolicStore<B>,
+    indexer: &TemporalIndexer<Uuid>,
+    n: usize,
+) -> Vec<SymbolicNode> {
+    indexer
+        .get_recent(n)
+        .into_iter()
+        .filter_map(|t| store.get_node(t.data))
+        .collect()
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,3 +11,5 @@ mod conversation_memory_sit;
 mod conversation_memory_uat;
 mod test_end_to_end;
 mod uat_tests;
+mod retrieval_pipeline_sit;
+mod retrieval_pipeline_uat;

--- a/tests/integration/retrieval_pipeline_sit.rs
+++ b/tests/integration/retrieval_pipeline_sit.rs
@@ -1,0 +1,36 @@
+use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+use hipcortex::retrieval_pipeline::recent_symbols;
+use hipcortex::symbolic_store::SymbolicStore;
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::collections::HashMap;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn retrieval_round_trip() {
+    let mut store = SymbolicStore::new();
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    let id = store.add_node("Article", HashMap::new());
+
+    let input = PerceptInput {
+        modality: Modality::Text,
+        text: Some("article content".into()),
+        embedding: None,
+        image_data: None,
+        tags: vec![],
+    };
+    PerceptionAdapter::adapt(input);
+
+    indexer.insert(TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: id,
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    });
+
+    let result = recent_symbols(&store, &indexer, 1);
+    assert_eq!(result[0].label, "Article");
+}

--- a/tests/integration/retrieval_pipeline_uat.rs
+++ b/tests/integration/retrieval_pipeline_uat.rs
@@ -1,0 +1,30 @@
+use hipcortex::retrieval_pipeline::recent_symbols;
+use hipcortex::symbolic_store::SymbolicStore;
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn user_retrieve_recent_document() {
+    let store = Arc::new(Mutex::new(SymbolicStore::new()));
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    let mut guard = store.lock().unwrap();
+    let doc_id = guard.add_node("Manual", HashMap::new());
+    drop(guard);
+
+    indexer.insert(TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: doc_id,
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    });
+
+    let nodes = recent_symbols(&store.lock().unwrap(), &indexer, 1);
+    assert_eq!(nodes[0].label, "Manual");
+}

--- a/tests/test_report/RetrievalPipelineTestPlan.md
+++ b/tests/test_report/RetrievalPipelineTestPlan.md
@@ -1,0 +1,17 @@
+# Retrieval Pipeline Test Plan
+
+*Date: June 5, 2025*
+
+This document lists the tests validating retrieval pipelines for RAG built on top of the `SymbolicStore` and `TemporalIndexer`.
+
+## Unit Tests
+- **recent_symbols_returns_nodes:** ensures that retrieving recent symbols yields the expected `SymbolicNode` from the store.
+- **recent_symbols_limit:** verifies that the number of results respects the `n` argument.
+
+## System Integration Tests
+- **retrieval_round_trip:** inserts a node, adapts a perception input, stores a temporal trace, and retrieves the node via the pipeline.
+
+## User Acceptance Tests
+- **user_retrieve_recent_document:** simulates a user storing a document and fetching it with the retrieval pipeline.
+
+All tests pass using `cargo test`, confirming the pipeline works across modules.

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -11,6 +11,7 @@ mod reasoning_trace_store_tests;
 mod snapshot_manager_tests;
 mod symbolic_store_tests;
 mod temporal_indexer_tests;
+mod retrieval_pipeline_tests;
 mod vision_encoder_tests;
 mod world_model_export_tests;
 mod conversation_memory_tests;

--- a/tests/unit/retrieval_pipeline_tests.rs
+++ b/tests/unit/retrieval_pipeline_tests.rs
@@ -1,0 +1,48 @@
+use hipcortex::retrieval_pipeline::recent_symbols;
+use hipcortex::symbolic_store::SymbolicStore;
+use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
+use std::collections::HashMap;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+#[test]
+fn recent_symbols_returns_nodes() {
+    let mut store = SymbolicStore::new();
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    let id = store.add_node("Doc", HashMap::new());
+    let trace = TemporalTrace {
+        id: Uuid::new_v4(),
+        timestamp: SystemTime::now(),
+        data: id,
+        relevance: 1.0,
+        decay_factor: 1.0,
+        last_access: SystemTime::now(),
+    };
+    indexer.insert(trace);
+
+    let result = recent_symbols(&store, &indexer, 1);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].label, "Doc");
+}
+
+#[test]
+fn recent_symbols_limit() {
+    let mut store = SymbolicStore::new();
+    let mut indexer = TemporalIndexer::new(4, 3600);
+
+    for i in 0..3 {
+        let id = store.add_node(&format!("N{}", i), HashMap::new());
+        indexer.insert(TemporalTrace {
+            id: Uuid::new_v4(),
+            timestamp: SystemTime::now(),
+            data: id,
+            relevance: 1.0,
+            decay_factor: 1.0,
+            last_access: SystemTime::now(),
+        });
+    }
+
+    let result = recent_symbols(&store, &indexer, 2);
+    assert_eq!(result.len(), 2);
+}


### PR DESCRIPTION
## Summary
- add simple retrieval_pipeline module for SymbolicStore and TemporalIndexer
- implement unit, SIT and UAT tests for retrieval pipeline
- document retrieval pipeline test plan

## Testing
- `cargo test --quiet`
