### PR TITLE
Update integration guide and test reports

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -13,11 +13,13 @@ This document describes how to integrate HipCortex with agent frameworks, APIs, 
 ## Integration Readiness
 
 ### REST/gRPC API
-- IntegrationLayer (`src/integration_layer.rs`) is structured to expose REST/gRPC endpoints.
-- To implement a REST server: use [actix-web](https://actix.rs/) or [axum](https://github.com/tokio-rs/axum).
-- To implement gRPC: use [tonic](https://github.com/hyperium/tonic).
-  When the `grpc-server` feature is enabled, `grpc_server::serve` runs a basic
-  MemoryService for adding and listing memory records.
+- IntegrationLayer (`src/integration_layer.rs`) exposes message handling that can
+  be wired to REST or gRPC endpoints.
+- To spin up the built-in REST server, compile with the `web-server` feature and
+  call `web_server::run(addr)` or `run_with_store` from your application.
+- To run the gRPC service, compile with the `grpc-server` feature and call
+  `grpc_server::serve(addr, store).await`.
+  This provides a basic `MemoryService` for adding and listing memory records.
 
 ### Agent Protocols (Planned)
 - OpenManus and MCP: Protocol stubs ready; bridge implementation in IntegrationLayer and AureusBridge.

--- a/tests/test_report/SITTestReport.md
+++ b/tests/test_report/SITTestReport.md
@@ -7,6 +7,10 @@ This report summarizes the system integration tests validating interactions acro
 - **memory_round_trip:** inserts a symbolic node, stores it in temporal memory, adapts a perception input, and verifies retrieval.
 - **integration_and_reflexion:** initializes the IntegrationLayer and AureusBridge together without errors.
 - **integration_chain_of_thought:** verifies CoT prompts are stored when triggered via the IntegrationLayer.
+- **grpc_add_and_list:** ensures the gRPC memory service accepts a record and
+  lists it back when the `grpc-server` feature is enabled.
+- **web_server_graph_endpoint:** verifies the REST `/graph` endpoint serves the
+  symbolic graph when running with the `web-server` feature.
 - **store_reasoning_trace_via_adapter_and_indexer:** validates storing a text percept as a temporal trace.
 - **query_symbol_via_indexer:** verifies querying nodes via label and property after retrieval from TemporalIndexer.
 

--- a/tests/test_report/UATTestReport.md
+++ b/tests/test_report/UATTestReport.md
@@ -9,5 +9,7 @@ These tests validate end user workflows using the memory engine.
 - **athena_chain_of_thought_reasoning:** validates CoT reflexion results are persisted for user review.
 - **user_store_reasoning_trace:** captures a user message and persists it in temporal memory.
 - **user_query_city_by_label:** ensures cities can be retrieved by label for end-user exploration.
+- **web_server_graph_endpoint:** confirms the REST API returns the symbolic
+  graph for user inspection when the web server is enabled.
 
 All user acceptance tests pass, demonstrating typical user scenarios complete successfully.


### PR DESCRIPTION
## Summary
- clarify how to enable REST and gRPC APIs in the integration guide
- document gRPC and web server tests in SIT and UAT reports

## Testing
- `cargo test --features "web-server grpc-server"`