### PR TITLE
Add OpenManus SIT test module

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -22,8 +22,9 @@ This document describes how to integrate HipCortex with agent frameworks, APIs, 
   This provides a basic `MemoryService` for adding and listing memory records.
 
 ### Agent Protocols (Planned)
-- OpenManus and MCP: Protocol stubs ready; bridge implementation in IntegrationLayer and AureusBridge.
-- Accept agent messages via PerceptionAdapter, return actions/results via IntegrationLayer.
+- **OpenManus** and **MCP** adapters will translate their native message formats into the internal `PerceptInput` structure. A small protocol bridge will live in `IntegrationLayer` so agents can talk to HipCortex directly over these protocols.
+- Agent messages flow **into** the engine through `PerceptionAdapter` which normalizes text, embeddings or structured agent events.
+- `IntegrationLayer` then exposes the results back over the same channel (or via REST/gRPC) so the calling agent receives the action or trace response.
 
 ### Chain-of-Thought & Reflexion
 - AureusBridge connects to agentic/LLM reasoning modules.

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -1,0 +1,21 @@
+# Test Plan
+
+This document lists the main test scenarios for verifying the OpenManus/MCP integration path.
+
+## Unit Tests
+- `conversation_memory_tests::ingest_openmanus_json` – verifies that OpenManus JSON messages are parsed into `ConversationMemory`.
+- `integration_layer_tests::*` – basic connection, authentication and message send logic of `IntegrationLayer`.
+- `perception_adapter_tests::adapt_text` – exercises the `PerceptionAdapter` with text inputs.
+
+## System Integration Tests (SIT)
+- `conversation_memory_sit::openmanus_round_trip_into_store` – end to end flow from conversation memory into a memory store.
+- `openmanus_integration_sit::openmanus_message_through_adapter_and_layer` – sends an OpenManus message through the `PerceptionAdapter` and out via `IntegrationLayer`.
+
+## User Acceptance Tests (UAT)
+- `conversation_memory_uat::user_flow_conversation_memory` – mimics a user session storing messages and sending a final result through the `IntegrationLayer`.
+
+Run all tests with:
+```bash
+cargo test
+```
+All tests should pass without failures.

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -8,6 +8,7 @@ mod system_integration_tests;
 mod world_model_cli_sit;
 mod world_model_uat;
 mod conversation_memory_sit;
+mod openmanus_integration_sit;
 mod conversation_memory_uat;
 mod test_end_to_end;
 mod uat_tests;

--- a/tests/integration/openmanus_integration_sit.rs
+++ b/tests/integration/openmanus_integration_sit.rs
@@ -1,0 +1,26 @@
+use hipcortex::conversation_memory::ConversationMemory;
+use hipcortex::integration_layer::IntegrationLayer;
+use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+
+#[test]
+fn openmanus_message_through_adapter_and_layer() {
+    let json = r#"{"role":"user","content":"ping"}"#;
+    let mut conv = ConversationMemory::new();
+    conv.ingest_openmanus(json).unwrap();
+    let msg = conv.messages().last().unwrap().clone();
+
+    let input = PerceptInput {
+        modality: Modality::AgentMessage,
+        text: Some(msg.text.clone()),
+        embedding: None,
+        image_data: None,
+        tags: vec!["sit".into()],
+    };
+    PerceptionAdapter::adapt(input);
+
+    let mut layer = IntegrationLayer::new();
+    layer.connect();
+    layer.add_api_key("k".into());
+    layer.send_message("k", &msg.text);
+    assert!(layer.is_connected());
+}


### PR DESCRIPTION
## Summary
- expand integration guide on OpenManus/MCP adapter workflow
- record unit/System/UAT coverage in a new `test_plan.md`
- add system integration test for OpenManus message round trip
- register the new SIT test in the integration test module

## Testing
- `cargo test --quiet`