### PR TITLE
Add WASM plugin host example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and reasoning components.
 - **Optional Web Server:** compile with `--features web-server` for an Axum REST API.
 - **Optional GUI:** compile with `--features gui` to launch a Tauri desktop client.
 - **RocksDB Backend:** compile with `--features rocksdb-backend` and use `MemoryStore::new_rocksdb` for an embedded key-value database.
+- **WASM Plugin Host:** compile with `--features plugin` to run custom WebAssembly extensions via `PluginHost`.
 - **Effort Evaluator & Confidence Regulator (planned):** track reasoning fatigue and decay to prevent collapse.
 - **Hypothesis Manager (planned):** maintain multiple reasoning paths and a quantized state tree for backtracking.
 - **Puzzle Benchmark Suite (planned):** validates complex planning algorithms like Tower of Hanoi and 8-puzzle.
@@ -77,6 +78,8 @@ cargo bench       # Run benchmarks
 If you encounter Codex container timeouts, run `scripts/codex_startup.sh` before heavy builds to prefetch dependencies and perform a quick `cargo check --all-features`.
 
 See examples/quickstart.rs for a minimal programmatic usage demo.
+For WebAssembly extension, see `examples/plugin_host.rs` and run:
+`cargo run --example plugin_host --features plugin`.
 Detailed data model and extended architecture diagrams are available in [docs/data_model.md](docs/data_model.md) and [docs/architecture.md](docs/architecture.md).
 
 ## 🛠️ Use Cases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ IndexMap based lookup tables accelerate queries by actor, action and target.
 `IntegrationLayer` can also register OAuth2 bearer tokens. Incoming JSON payloads are validated with Serde custom validators to reject malformed input.
 `AuditLog::verify` can be used to confirm the Merkle chain has not been tampered with.
 
-The new `MemoryBackend` trait enables pluggable persistence layers. A RocksDB-backed implementation is provided in addition to the default file backend so deployments can use an embedded key-value store without code changes. `TemporalIndexer` now uses a segmented ring buffer for better scalability. `SymbolicStore` caches recent label lookups with an LRU cache to speed up graph queries. `ProceduralCache` can save and load checkpoints for resilience. Optional WASM plugins run through a `PluginHost` when compiled with the `plugin` feature.
+The new `MemoryBackend` trait enables pluggable persistence layers. A RocksDB-backed implementation is provided in addition to the default file backend so deployments can use an embedded key-value store without code changes. `TemporalIndexer` now uses a segmented ring buffer for better scalability. `SymbolicStore` caches recent label lookups with an LRU cache to speed up graph queries. `ProceduralCache` can save and load checkpoints for resilience. Optional WASM plugins run through a `PluginHost` when compiled with the `plugin` feature. Build with `--features plugin` to enable this runtime extension capability.
 
 Additional modules extend HipCortex further:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,16 @@ let embedding = VisionEncoder::encode_path("image.png")?;
 
 The output will show insertions, FSM transitions, symbolic graph operations, and perception adapter traces.
 
+### Run a WASM plugin
+
+Compile with the `plugin` feature to enable the `PluginHost` and execute WebAssembly extensions:
+
+```sh
+cargo run --example plugin_host --features plugin
+```
+
+This runs `examples/plugin_host.rs` which loads a tiny WAT module and prints the returned value.
+
 ## 5. VS Code Setup
 
 * Open project root in VS Code.

--- a/examples/plugin_host.rs
+++ b/examples/plugin_host.rs
@@ -1,0 +1,19 @@
+use hipcortex::plugin_host::PluginHost;
+
+fn main() -> anyhow::Result<()> {
+    let host = PluginHost::new();
+    #[cfg(feature = "plugin")]
+    {
+        let wat = "(module (func (export \"run\") (result i32) i32.const 7))";
+        let bytes = wat::parse_str(wat)?;
+        let result = host.run_wasm(&bytes)?;
+        println!("Plugin returned: {}", result);
+    }
+    #[cfg(not(feature = "plugin"))]
+    {
+        if let Err(e) = host.run_wasm(&[]) {
+            println!("{}", e);
+        }
+    }
+    Ok(())
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,20 +1,22 @@
 mod cli_tests;
-#[cfg(feature = "grpc-server")]
-mod grpc_tests;
-mod integration_tests;
-mod llm_integration_tests;
-mod reasoning_trace_sit_tests;
-mod system_integration_tests;
-mod world_model_cli_sit;
-mod world_model_uat;
 mod conversation_memory_sit;
-mod openmanus_integration_sit;
 mod conversation_memory_uat;
-mod test_end_to_end;
-mod uat_tests;
-mod retrieval_pipeline_sit;
-mod retrieval_pipeline_uat;
 mod edge_workflow_sit;
 mod edge_workflow_uat;
-mod smart_glasses_sit;
+#[cfg(feature = "grpc-server")]
+mod grpc_tests;
 mod humanoid_perception_uat;
+mod integration_tests;
+mod llm_integration_tests;
+mod openmanus_integration_sit;
+mod plugin_host_sit;
+mod plugin_host_uat;
+mod reasoning_trace_sit_tests;
+mod retrieval_pipeline_sit;
+mod retrieval_pipeline_uat;
+mod smart_glasses_sit;
+mod system_integration_tests;
+mod test_end_to_end;
+mod uat_tests;
+mod world_model_cli_sit;
+mod world_model_uat;

--- a/tests/integration/plugin_host_sit.rs
+++ b/tests/integration/plugin_host_sit.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "plugin")]
+use hipcortex::memory_record::{MemoryRecord, MemoryType};
+#[cfg(feature = "plugin")]
+use hipcortex::memory_store::MemoryStore;
+use hipcortex::plugin_host::PluginHost;
+
+#[test]
+fn plugin_generates_memory() {
+    let host = PluginHost::new();
+    #[cfg(feature = "plugin")]
+    {
+        let path = "plugin_sit.jsonl";
+        let _ = std::fs::remove_file(path);
+        let mut store = MemoryStore::new(path).unwrap();
+        let wat = "(module (func (export \"run\") (result i32) i32.const 5))";
+        let bytes = wat::parse_str(wat).unwrap();
+        let result = host.run_wasm(&bytes).unwrap();
+        store
+            .add(MemoryRecord::new(
+                MemoryType::Procedural,
+                "plugin".into(),
+                "run".into(),
+                result.to_string(),
+                serde_json::json!({}),
+            ))
+            .unwrap();
+        assert_eq!(store.all().len(), 1);
+        std::fs::remove_file(path).unwrap();
+    }
+    #[cfg(not(feature = "plugin"))]
+    {
+        assert!(host.run_wasm(&[]).is_err());
+    }
+}

--- a/tests/integration/plugin_host_uat.rs
+++ b/tests/integration/plugin_host_uat.rs
@@ -1,0 +1,17 @@
+use hipcortex::plugin_host::PluginHost;
+
+#[test]
+fn user_executes_plugin() {
+    let host = PluginHost::new();
+    #[cfg(feature = "plugin")]
+    {
+        let wat = "(module (func (export \"run\") (result i32) i32.const 3))";
+        let bytes = wat::parse_str(wat).unwrap();
+        let result = host.run_wasm(&bytes).unwrap();
+        assert_eq!(result, 3);
+    }
+    #[cfg(not(feature = "plugin"))]
+    {
+        assert!(host.run_wasm(&[]).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- document how to run WASM plugins
- provide plugin_host.rs example
- add system and acceptance tests for PluginHost

## Testing
- `cargo test`