### PR TITLE
Add Enhancement Advisor module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ and reasoning components.
 - **WASM Plugin Host:** compile with `--features plugin` to run custom WebAssembly extensions via `PluginHost`.
 - **Effort Evaluator & Confidence Regulator:** monitor reasoning effort and confidence to avoid collapse.
 - **Hypothesis Manager:** maintain multiple reasoning paths and a quantized state tree for backtracking.
+- **Enhancement Advisor:** analyze module metrics and recommend improvements for human review.
 - **Puzzle Benchmark Suite:** validates complex planning algorithms like Tower of Hanoi and 8-puzzle.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,7 @@ Additional modules extend HipCortex further:
 - **gRPC Server**: enabling the `grpc-server` feature spins up a Tonic-based service for adding and listing memory records.
  - **Effort Evaluator & Confidence Regulator**: measure reasoning effort and confidence decay to avoid collapse.
  - **Hypothesis Manager**: maintain multiple reasoning branches and a quantized state tree for backtracking.
+- **Enhancement Advisor**: evaluate module metrics and suggest improvements for human operators.
 - **Puzzle Benchmark Suite**: verifies complex planning algorithms to gauge collapse resilience.
 
 ## Value Stream Data Collection
@@ -130,6 +131,7 @@ Each module gathers metrics to validate behavior and ensure consistency:
 | Dashboard/GUI | Real-time graphs | Visualization algorithms |
 | SemanticCompression | Compression ratio | Information theory |
 | MemoryDiff | Snapshot differences | Diff algorithms |
+| EnhancementAdvisor | Optimization hints | Heuristic analysis |
 
 ## Mathematical Foundations
 

--- a/docs/business_context.md
+++ b/docs/business_context.md
@@ -31,3 +31,4 @@ The project is written in Rust to ensure performance and safety, with optional w
 2. **Query symbols** – explore the graph-based SymbolicStore for concepts and relationships.
 3. **Update state** – manage FSM transitions or Reflexion loops with the ProceduralCache and AureusBridge.
 4. **Visualize world model** – real-time CLI and web dashboards show stored state and reasoning traces.
+5. **Review suggestions** – the Enhancement Advisor analyzes metrics from every component and recommends improvements that users can approve.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,5 +44,6 @@ The following actions reinforce the math-driven data foundation:
 3. **Add Property-Based Tests** – stress-test symbolic and temporal modules with proptest.
 4. **Pilot Statistical Monitoring** – collect moving averages and standard deviation for key metrics.
 5. **Automate Observability Dashboards** – integrate logs and metrics in the web dashboard.
+6. **Deploy Enhancement Advisor** – surface reasoning-based suggestions for users to approve and refine.
 
 PRs for new modules and improvements are highly encouraged!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod conversation_memory;
 pub mod dashboard;
 #[path = "modules/effort.rs"]
 pub mod effort;
+#[path = "modules/enhancement_advisor.rs"]
+pub mod enhancement_advisor;
 #[cfg(feature = "gui")]
 pub mod gui;
 #[path = "modules/hypothesis_manager.rs"]

--- a/src/modules/enhancement_advisor.rs
+++ b/src/modules/enhancement_advisor.rs
@@ -1,0 +1,62 @@
+/// Analyze component metrics and suggest improvements for human review.
+#[derive(Clone, Debug)]
+pub struct ComponentMetric {
+    pub name: String,
+    pub value: f64,
+}
+
+pub struct EnhancementAdvisor {
+    suggestions: Vec<String>,
+}
+
+impl EnhancementAdvisor {
+    pub fn new() -> Self {
+        Self {
+            suggestions: Vec::new(),
+        }
+    }
+
+    /// Analyze metrics for a component and store a text suggestion.
+    pub fn analyze(&mut self, component: &str, metrics: &[ComponentMetric]) {
+        if metrics.is_empty() {
+            return;
+        }
+        let avg: f64 = metrics.iter().map(|m| m.value).sum::<f64>() / metrics.len() as f64;
+        if avg < 0.5 {
+            self.suggestions.push(format!(
+                "{component} metrics low; consider tuning parameters or scaling resources"
+            ));
+        } else {
+            self.suggestions
+                .push(format!("{component} operating within expected range"));
+        }
+    }
+
+    /// Get all accumulated suggestions.
+    pub fn recommendations(&self) -> &[String] {
+        &self.suggestions
+    }
+
+    /// Clear stored suggestions.
+    pub fn reset(&mut self) {
+        self.suggestions.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advisor_collects_suggestions() {
+        let mut adv = EnhancementAdvisor::new();
+        let metrics = vec![ComponentMetric {
+            name: "latency".into(),
+            value: 0.3,
+        }];
+        adv.analyze("IntegrationLayer", &metrics);
+        assert_eq!(adv.recommendations().len(), 1);
+        adv.reset();
+        assert!(adv.recommendations().is_empty());
+    }
+}

--- a/tests/unit/enhancement_advisor_tests.rs
+++ b/tests/unit/enhancement_advisor_tests.rs
@@ -1,0 +1,21 @@
+use hipcortex::enhancement_advisor::{ComponentMetric, EnhancementAdvisor};
+
+#[test]
+fn basic_advisor_usage() {
+    let mut adv = EnhancementAdvisor::new();
+    let metrics = vec![
+        ComponentMetric {
+            name: "latency".into(),
+            value: 0.4,
+        },
+        ComponentMetric {
+            name: "error_rate".into(),
+            value: 0.4,
+        },
+    ];
+    adv.analyze("IntegrationLayer", &metrics);
+    assert_eq!(adv.recommendations().len(), 1);
+    assert!(adv.recommendations()[0].contains("IntegrationLayer"));
+    adv.reset();
+    assert!(adv.recommendations().is_empty());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -5,6 +5,7 @@ mod aureus_bridge_tests;
 mod conversation_memory_tests;
 mod edge_workflow_small;
 mod effort_tests;
+mod enhancement_advisor_tests;
 mod hypothesis_manager_tests;
 mod integration_layer_tests;
 mod knowledge_export_tests;


### PR DESCRIPTION
## Summary
- introduce `EnhancementAdvisor` for reasoning over component metrics
- expose the module via `src/lib.rs`
- document the advisor in README and architecture docs
- mention new capability in business context and roadmap
- add unit tests for the advisor

## Testing
- `cargo test --quiet`