### PR TITLE
Improve perception adapter with PCA and checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1"
 flate2 = "1"
 tar = "0.4"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
+nalgebra = "0.33"
 diesel = { version = "2", features = ["postgres", "sqlite", "serde_json"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 sha2 = "0.10"
@@ -54,6 +55,7 @@ predicates = "3"
 pollster = "0.3"
 tempfile = "3"
 mockito = "1"
+approx = "0.5"
 
 [build-dependencies]
 tonic-build = { version = "0.9", optional = true }

--- a/src/modules/perception_adapter.rs
+++ b/src/modules/perception_adapter.rs
@@ -1,4 +1,7 @@
 /// Chain-of-Thought: input -> symbol parse -> PCA -> compressed vector
+use nalgebra::DMatrix;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone)]
 pub enum Modality {
@@ -19,6 +22,25 @@ pub struct PerceptInput {
 }
 
 pub struct PerceptionAdapter;
+
+#[derive(Debug)]
+pub enum AdapterError {
+    RateLimited,
+    InvalidInput(&'static str),
+    ImageEncoding(anyhow::Error),
+}
+
+impl std::fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdapterError::RateLimited => write!(f, "rate limit exceeded"),
+            AdapterError::InvalidInput(s) => write!(f, "invalid input: {}", s),
+            AdapterError::ImageEncoding(e) => write!(f, "image encoding error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for AdapterError {}
 
 const COMPRESS_DIM: usize = 4;
 
@@ -55,57 +77,131 @@ lazy_static::lazy_static! {
     static ref ADAPTER_LIMITER: RateLimiter = RateLimiter::new(10);
 }
 
+fn l2_normalize(mut v: Vec<f32>) -> Vec<f32> {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for val in v.iter_mut() {
+            *val /= norm;
+        }
+    }
+    v
+}
+
+fn shannon_entropy(v: &[f32]) -> f32 {
+    let sum: f32 = v.iter().map(|x| x.abs()).sum();
+    if sum == 0.0 {
+        return 0.0;
+    }
+    let mut ent = 0.0;
+    for x in v {
+        let p = x.abs() / sum;
+        if p > 0.0 {
+            ent -= p * p.log2();
+        }
+    }
+    ent
+}
+
+fn text_to_embedding(text: &str, dim: usize) -> Vec<f32> {
+    let mut vec = vec![0.0; dim];
+    for token in text.split_whitespace() {
+        let mut hasher = DefaultHasher::new();
+        token.hash(&mut hasher);
+        let idx = (hasher.finish() as usize) % dim;
+        vec[idx] += 1.0;
+    }
+    vec
+}
+
+fn pca_compress(data: &[f32], new_dim: usize) -> Vec<f32> {
+    if new_dim == 0 || data.is_empty() {
+        return vec![];
+    }
+    if data.len() < new_dim {
+        return crate::semantic_compression::compress_embedding(data, new_dim);
+    }
+    let rows = data.len() - new_dim + 1;
+    let mut mat_data = Vec::with_capacity(rows * new_dim);
+    for i in 0..rows {
+        for j in 0..new_dim {
+            mat_data.push(data[i + j]);
+        }
+    }
+    let mut m = DMatrix::from_row_slice(rows, new_dim, &mat_data);
+    for c in 0..new_dim {
+        let mean: f32 = (0..rows).map(|r| m[(r, c)]).sum::<f32>() / rows as f32;
+        for r in 0..rows {
+            m[(r, c)] -= mean;
+        }
+    }
+    let svd = m.svd(true, true);
+    let vt = svd.v_t.unwrap();
+    let mut out = vec![0.0; new_dim];
+    for i in 0..new_dim {
+        let mut val = 0.0;
+        for j in 0..new_dim {
+            val += data[j] * vt[(i, j)];
+        }
+        out[i] = val;
+    }
+    out
+}
+
 impl PerceptionAdapter {
-    pub fn adapt(input: PerceptInput) -> Option<Vec<f32>> {
+    pub fn adapt(input: PerceptInput) -> Result<Vec<f32>, AdapterError> {
         if !ADAPTER_LIMITER.allow() {
-            println!("[PerceptionAdapter] rate limit exceeded");
-            return None;
+            return Err(AdapterError::RateLimited);
         }
         match input.modality {
             Modality::Text => {
-                println!("[PerceptionAdapter] Text: {:?}", input.text);
-                None
+                let text = input.text.ok_or(AdapterError::InvalidInput("missing text"))?;
+                let emb = text_to_embedding(&text, COMPRESS_DIM * 4);
+                let comp = pca_compress(&emb, COMPRESS_DIM);
+                let out = l2_normalize(comp);
+                let ent = shannon_entropy(&out);
+                println!("[PerceptionAdapter] entropy {:.3}", ent);
+                Ok(out)
             }
             Modality::ImageEmbedding => {
                 if let Some(embed) = input.embedding {
-                    let comp =
-                        crate::semantic_compression::compress_embedding(&embed, COMPRESS_DIM);
-                    println!("[PerceptionAdapter] Embedding: {:?}", comp);
-                    Some(comp)
+                    let comp = pca_compress(&embed, COMPRESS_DIM);
+                    let out = l2_normalize(comp);
+                    println!("[PerceptionAdapter] entropy {:.3}", shannon_entropy(&out));
+                    Ok(out)
                 } else {
-                    println!("[PerceptionAdapter] Embedding: None");
-                    None
+                    Err(AdapterError::InvalidInput("missing embedding"))
                 }
             }
             Modality::Image => {
                 if let Some(bytes) = input.image_data {
                     match crate::vision_encoder::VisionEncoder::encode_bytes(&bytes) {
                         Ok(emb) => {
-                            let comp =
-                                crate::semantic_compression::compress_embedding(&emb, COMPRESS_DIM);
-                            println!("[PerceptionAdapter] Image embedding: {:?}", comp);
-                            Some(comp)
+                            let comp = pca_compress(&emb, COMPRESS_DIM);
+                            let out = l2_normalize(comp);
+                            println!("[PerceptionAdapter] entropy {:.3}", shannon_entropy(&out));
+                            Ok(out)
                         }
-                        Err(e) => {
-                            println!("[PerceptionAdapter] Image encoding error: {}", e);
-                            None
-                        }
+                        Err(e) => Err(AdapterError::ImageEncoding(e)),
                     }
                 } else {
-                    println!("[PerceptionAdapter] No image data");
-                    None
+                    Err(AdapterError::InvalidInput("no image data"))
                 }
             }
             Modality::SymbolicConcept => {
-                println!(
-                    "[PerceptionAdapter] Symbolic concept tags: {:?}",
-                    input.tags
-                );
-                None
+                if input.tags.is_empty() {
+                    Err(AdapterError::InvalidInput("empty tags"))
+                } else {
+                    println!("[PerceptionAdapter] Symbolic concept tags: {:?}", input.tags);
+                    Ok(Vec::new())
+                }
             }
-            _ => {
-                println!("[PerceptionAdapter] Input: {:?}", input);
-                None
+            Modality::AgentMessage => {
+                let text = input.text.ok_or(AdapterError::InvalidInput("missing text"))?;
+                let emb = text_to_embedding(&text, COMPRESS_DIM * 4);
+                let comp = pca_compress(&emb, COMPRESS_DIM);
+                let out = l2_normalize(comp);
+                println!("[PerceptionAdapter] entropy {:.3}", shannon_entropy(&out));
+                Ok(out)
             }
         }
     }
@@ -124,19 +220,23 @@ mod tests {
             image_data: None,
             tags: vec![],
         };
-        PerceptionAdapter::adapt(input);
+        let out = PerceptionAdapter::adapt(input).unwrap();
+        assert_eq!(out.len(), COMPRESS_DIM);
     }
 
     #[test]
     fn rate_limit() {
+        let mut last = None;
         for _ in 0..12 {
-            PerceptionAdapter::adapt(PerceptInput {
+            last = Some(PerceptionAdapter::adapt(PerceptInput {
                 modality: Modality::Text,
                 text: Some("x".into()),
                 embedding: None,
                 image_data: None,
                 tags: vec![],
-            });
+            }));
         }
+        let result = last.unwrap();
+        assert!(matches!(result.unwrap_err(), AdapterError::RateLimited));
     }
 }

--- a/tests/integration/humanoid_perception_uat.rs
+++ b/tests/integration/humanoid_perception_uat.rs
@@ -18,8 +18,8 @@ fn user_flow_humanoid_robotics_trace() {
         image_data: None,
         tags: vec!["humanoid".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
 
     indexer.insert(TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/integration/openmanus_integration_sit.rs
+++ b/tests/integration/openmanus_integration_sit.rs
@@ -16,8 +16,8 @@ fn openmanus_message_through_adapter_and_layer() {
         image_data: None,
         tags: vec!["sit".into()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert_eq!(out.len(), 4);
 
     let mut layer = IntegrationLayer::new();
     layer.connect();

--- a/tests/integration/reasoning_trace_sit_tests.rs
+++ b/tests/integration/reasoning_trace_sit_tests.rs
@@ -13,8 +13,8 @@ fn store_reasoning_trace_via_adapter_and_indexer() {
         image_data: None,
         tags: vec!["sit".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
     let trace = TemporalTrace {
         id: Uuid::new_v4(),
         timestamp: SystemTime::now(),

--- a/tests/integration/retrieval_pipeline_sit.rs
+++ b/tests/integration/retrieval_pipeline_sit.rs
@@ -20,8 +20,8 @@ fn retrieval_round_trip() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert_eq!(out.len(), 4);
 
     indexer.insert(TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/integration/system_integration_tests.rs
+++ b/tests/integration/system_integration_tests.rs
@@ -32,8 +32,8 @@ fn memory_round_trip() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() == 4);
 
     assert!(store.get_node(node_id).is_some());
     assert_eq!(indexer.get_recent(1)[0].data, node_id);

--- a/tests/integration/uat_tests.rs
+++ b/tests/integration/uat_tests.rs
@@ -67,8 +67,8 @@ fn user_store_reasoning_trace() {
         image_data: None,
         tags: vec!["uat".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
 
     let trace = TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/unit/perception_adapter_tests.rs
+++ b/tests/unit/perception_adapter_tests.rs
@@ -1,4 +1,4 @@
-use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+use hipcortex::perception_adapter::{AdapterError, Modality, PerceptInput, PerceptionAdapter};
 
 #[test]
 fn adapt_text_input() {
@@ -9,8 +9,8 @@ fn adapt_text_input() {
         image_data: None,
         tags: vec!["tag1".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() <= 4);
 }
 
 #[test]
@@ -22,8 +22,8 @@ fn adapt_embedding_input() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_some());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() <= 4);
 }
 
 #[test]
@@ -35,8 +35,8 @@ fn adapt_invalid_input() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let err = PerceptionAdapter::adapt(input).unwrap_err();
+    assert!(matches!(err, AdapterError::InvalidInput(_)));
 }
 
 #[test]
@@ -48,8 +48,8 @@ fn adapt_image_input() {
         image_data: Some(vec![1, 2, 3]),
         tags: vec!["img".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let err = PerceptionAdapter::adapt(input).unwrap_err();
+    assert!(matches!(err, AdapterError::ImageEncoding(_)));
 }
 
 #[test]
@@ -61,6 +61,6 @@ fn adapt_symbolic_concept() {
         image_data: None,
         tags: vec!["concept".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.is_empty());
 }

--- a/tests/unit/reasoning_trace_store_tests.rs
+++ b/tests/unit/reasoning_trace_store_tests.rs
@@ -13,8 +13,8 @@ fn store_trace_after_perception() {
         image_data: None,
         tags: vec!["unit".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
     let trace = TemporalTrace {
         id: Uuid::new_v4(),
         timestamp: SystemTime::now(),


### PR DESCRIPTION
## Summary
- add `nalgebra` dependency
- implement PCA compression, L2 normalization and entropy logging
- return `Result` from `PerceptionAdapter::adapt`
- embed text and agent messages through hashed bag-of-words
- update unit and integration tests

## Testing
- `cargo test --quiet`