### PR TITLE
Improve perception adapter with PCA and checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1"
 flate2 = "1"
 tar = "0.4"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
+nalgebra = "0.33"
 diesel = { version = "2", features = ["postgres", "sqlite", "serde_json"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 sha2 = "0.10"
@@ -54,6 +55,7 @@ predicates = "3"
 pollster = "0.3"
 tempfile = "3"
 mockito = "1"
+approx = "0.5"
 
 [build-dependencies]
 tonic-build = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod memory_store;
 pub mod perception_adapter;
 pub mod persistence;
 pub mod plugin_host;
+pub mod math;
 #[path = "modules/procedural_cache.rs"]
 pub mod procedural_cache;
 #[path = "modules/puzzle.rs"]

--- a/src/math/entropy.rs
+++ b/src/math/entropy.rs
@@ -1,0 +1,27 @@
+/// Estimate Shannon entropy of a vector by treating values as absolute weights.
+pub fn estimate_entropy(v: &[f32]) -> f32 {
+    let sum: f32 = v.iter().map(|x| x.abs()).sum();
+    if sum == 0.0 {
+        return 0.0;
+    }
+    let mut ent = 0.0;
+    for x in v {
+        let p = x.abs() / sum;
+        if p > 0.0 {
+            ent -= p * p.log2();
+        }
+    }
+    ent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entropy_basic() {
+        let v = vec![1.0, 1.0, 1.0, 1.0];
+        let e = estimate_entropy(&v);
+        assert!((e - 2.0).abs() < 1e-3);
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,3 @@
+pub mod pca;
+pub mod entropy;
+pub mod norm;

--- a/src/math/norm.rs
+++ b/src/math/norm.rs
@@ -1,0 +1,22 @@
+/// Normalize a vector to unit L2 norm.
+pub fn l2_normalize(mut v: Vec<f32>) -> Vec<f32> {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for val in v.iter_mut() {
+            *val /= norm;
+        }
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn normalizes() {
+        let out = l2_normalize(vec![3.0, 4.0]);
+        assert_relative_eq!(out[0] * out[0] + out[1] * out[1], 1.0, epsilon = 1e-6);
+    }
+}

--- a/src/math/pca.rs
+++ b/src/math/pca.rs
@@ -1,0 +1,55 @@
+use nalgebra::DMatrix;
+
+/// Reduce a single embedding using a simple PCA.
+/// Assumes data is 1-dimensional vector.
+/// Uses sliding window to form matrix then computes SVD.
+pub fn pca_reduce(data: &[f32], target_dim: usize) -> Vec<f32> {
+    if target_dim == 0 || data.is_empty() {
+        return Vec::new();
+    }
+    if data.len() < target_dim {
+        return data.to_vec();
+    }
+    // Build matrix using overlapping windows
+    let rows = data.len() - target_dim + 1;
+    let mut mat_data = Vec::with_capacity(rows * target_dim);
+    for i in 0..rows {
+        for j in 0..target_dim {
+            mat_data.push(data[i + j]);
+        }
+    }
+    let mut m = DMatrix::from_row_slice(rows, target_dim, &mat_data);
+    // Center columns
+    for c in 0..target_dim {
+        let mean: f32 = (0..rows).map(|r| m[(r, c)]).sum::<f32>() / rows as f32;
+        for r in 0..rows {
+            m[(r, c)] -= mean;
+        }
+    }
+    let svd = m.svd(true, true);
+    let vt = svd.v_t.unwrap();
+    let mut out = vec![0.0; target_dim];
+    for i in 0..target_dim {
+        let mut val = 0.0;
+        for j in 0..target_dim {
+            val += data[j] * vt[(i, j)];
+        }
+        out[i] = val;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn reduces_dimension() {
+        let input: Vec<f32> = (0..10).map(|v| v as f32).collect();
+        let out = pca_reduce(&input, 3);
+        assert_eq!(out.len(), 3);
+        let var: f32 = out.iter().map(|v| v * v).sum();
+        assert!(var > 0.0);
+    }
+}

--- a/tests/integration/humanoid_perception_uat.rs
+++ b/tests/integration/humanoid_perception_uat.rs
@@ -18,8 +18,8 @@ fn user_flow_humanoid_robotics_trace() {
         image_data: None,
         tags: vec!["humanoid".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
 
     indexer.insert(TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/integration/openmanus_integration_sit.rs
+++ b/tests/integration/openmanus_integration_sit.rs
@@ -16,8 +16,8 @@ fn openmanus_message_through_adapter_and_layer() {
         image_data: None,
         tags: vec!["sit".into()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert_eq!(out.len(), 4);
 
     let mut layer = IntegrationLayer::new();
     layer.connect();

--- a/tests/integration/reasoning_trace_sit_tests.rs
+++ b/tests/integration/reasoning_trace_sit_tests.rs
@@ -13,8 +13,8 @@ fn store_reasoning_trace_via_adapter_and_indexer() {
         image_data: None,
         tags: vec!["sit".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
     let trace = TemporalTrace {
         id: Uuid::new_v4(),
         timestamp: SystemTime::now(),

--- a/tests/integration/retrieval_pipeline_sit.rs
+++ b/tests/integration/retrieval_pipeline_sit.rs
@@ -20,8 +20,8 @@ fn retrieval_round_trip() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert_eq!(out.len(), 4);
 
     indexer.insert(TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/integration/system_integration_tests.rs
+++ b/tests/integration/system_integration_tests.rs
@@ -32,8 +32,8 @@ fn memory_round_trip() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() == 4);
 
     assert!(store.get_node(node_id).is_some());
     assert_eq!(indexer.get_recent(1)[0].data, node_id);

--- a/tests/integration/uat_tests.rs
+++ b/tests/integration/uat_tests.rs
@@ -67,8 +67,8 @@ fn user_store_reasoning_trace() {
         image_data: None,
         tags: vec!["uat".into()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
 
     let trace = TemporalTrace {
         id: Uuid::new_v4(),

--- a/tests/unit/perception_adapter_tests.rs
+++ b/tests/unit/perception_adapter_tests.rs
@@ -1,4 +1,4 @@
-use hipcortex::perception_adapter::{Modality, PerceptInput, PerceptionAdapter};
+use hipcortex::perception_adapter::{AdapterError, Modality, PerceptInput, PerceptionAdapter};
 
 #[test]
 fn adapt_text_input() {
@@ -9,8 +9,8 @@ fn adapt_text_input() {
         image_data: None,
         tags: vec!["tag1".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() <= 4);
 }
 
 #[test]
@@ -22,8 +22,8 @@ fn adapt_embedding_input() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_some());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.len() <= 4);
 }
 
 #[test]
@@ -35,8 +35,8 @@ fn adapt_invalid_input() {
         image_data: None,
         tags: vec![],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let err = PerceptionAdapter::adapt(input).unwrap_err();
+    assert!(matches!(err, AdapterError::InvalidInput(_)));
 }
 
 #[test]
@@ -48,8 +48,8 @@ fn adapt_image_input() {
         image_data: Some(vec![1, 2, 3]),
         tags: vec!["img".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let err = PerceptionAdapter::adapt(input).unwrap_err();
+    assert!(matches!(err, AdapterError::ImageEncoding(_)));
 }
 
 #[test]
@@ -61,6 +61,6 @@ fn adapt_symbolic_concept() {
         image_data: None,
         tags: vec!["concept".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input);
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input).unwrap();
+    assert!(out.is_empty());
 }

--- a/tests/unit/reasoning_trace_store_tests.rs
+++ b/tests/unit/reasoning_trace_store_tests.rs
@@ -13,8 +13,8 @@ fn store_trace_after_perception() {
         image_data: None,
         tags: vec!["unit".to_string()],
     };
-    let out = PerceptionAdapter::adapt(input.clone());
-    assert!(out.is_none());
+    let out = PerceptionAdapter::adapt(input.clone()).unwrap();
+    assert_eq!(out.len(), 4);
     let trace = TemporalTrace {
         id: Uuid::new_v4(),
         timestamp: SystemTime::now(),


### PR DESCRIPTION
## Summary
- add `nalgebra` dependency
- implement PCA compression, L2 normalization and entropy logging
- return `Result` from `PerceptionAdapter::adapt`
- embed text and agent messages through hashed bag-of-words
- move math helpers to new `math` module
- update unit and integration tests

## Testing
- `cargo test --quiet`