### PR TITLE
Add grid-based VisionEncoder

### DIFF
--- a/src/vision_encoder.rs
+++ b/src/vision_encoder.rs
@@ -1,14 +1,92 @@
 use anyhow::Result;
 use image::{DynamicImage, GenericImageView};
+use nalgebra::DMatrix;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::path::Path;
 
 pub struct VisionEncoder;
 
+const DEFAULT_GRID: usize = 4;
+const DEFAULT_PCA_DIM: usize = 8;
+
 impl VisionEncoder {
-    /// Encode a DynamicImage into a simple RGB mean vector.
+    /// Encode a DynamicImage into a normalized embedding.
     pub fn encode_image(image: &DynamicImage) -> Vec<f32> {
+        let grid_feats = Self::encode_image_grid(image, DEFAULT_GRID);
+        let reduced = Self::pca_reduce(&grid_feats, DEFAULT_PCA_DIM);
+        let normed = Self::l2_normalize(&reduced);
+        let ent = Self::estimate_entropy(&normed);
+        println!("[VisionEncoder] entropy {:.3}", ent);
+        normed
+    }
+
+    #[cfg(feature = "parallel")]
+    pub fn encode_images_parallel(images: &[DynamicImage]) -> Vec<Vec<f32>> {
+        images.par_iter().map(Self::encode_image).collect()
+    }
+
+    #[cfg(feature = "gpu")]
+    pub async fn encode_image_gpu(bytes: &[u8]) -> Result<Vec<f32>> {
+        // For now the GPU path simply loads the image and calls the CPU encoder
+        // to keep results consistent across platforms.
+        let img = image::load_from_memory(bytes)?;
+        Ok(Self::encode_image(&img))
+    }
+
+    /// Encode raw image bytes (PNG/JPEG) into an embedding.
+    pub fn encode_bytes(bytes: &[u8]) -> Result<Vec<f32>> {
+        let img = image::load_from_memory(bytes)?;
+        Ok(Self::encode_image(&img))
+    }
+
+    /// Encode image from a file path.
+    pub fn encode_path<P: AsRef<Path>>(path: P) -> Result<Vec<f32>> {
+        let img = image::open(path)?;
+        Ok(Self::encode_image(&img))
+    }
+
+    /// Divide the image into a grid and compute mean RGB per patch.
+    pub fn encode_image_grid(image: &DynamicImage, grid: usize) -> Vec<f32> {
+        let (w, h) = image.dimensions();
+        if grid == 0 || w < grid as u32 || h < grid as u32 {
+            return Self::legacy_mean(image);
+        }
+        let rgb = image.to_rgb8();
+        let mut out = Vec::with_capacity(grid * grid * 3);
+        for gy in 0..grid {
+            let y0 = (gy as u32 * h) / grid as u32;
+            let y1 = ((gy as u32 + 1) * h) / grid as u32;
+            for gx in 0..grid {
+                let x0 = (gx as u32 * w) / grid as u32;
+                let x1 = ((gx as u32 + 1) * w) / grid as u32;
+                let mut r_sum = 0u64;
+                let mut g_sum = 0u64;
+                let mut b_sum = 0u64;
+                let mut count = 0u64;
+                for y in y0..y1 {
+                    for x in x0..x1 {
+                        let p = rgb.get_pixel(x, y);
+                        r_sum += p[0] as u64;
+                        g_sum += p[1] as u64;
+                        b_sum += p[2] as u64;
+                        count += 1;
+                    }
+                }
+                if count == 0 {
+                    out.extend_from_slice(&[0.0, 0.0, 0.0]);
+                } else {
+                    let denom = count as f32 * 255.0;
+                    out.push(r_sum as f32 / denom);
+                    out.push(g_sum as f32 / denom);
+                    out.push(b_sum as f32 / denom);
+                }
+            }
+        }
+        out
+    }
+
+    fn legacy_mean(image: &DynamicImage) -> Vec<f32> {
         let (w, h) = image.dimensions();
         let rgb = image.to_rgb8();
         let mut r_sum = 0u64;
@@ -27,134 +105,64 @@ impl VisionEncoder {
         ]
     }
 
-    #[cfg(feature = "parallel")]
-    pub fn encode_images_parallel(images: &[DynamicImage]) -> Vec<Vec<f32>> {
-        images.par_iter().map(Self::encode_image).collect()
-    }
-
-    #[cfg(feature = "gpu")]
-    pub async fn encode_image_gpu(bytes: &[u8]) -> Result<Vec<f32>> {
-        use wgpu::util::DeviceExt;
-        let instance = wgpu::Instance::default();
-
-        let adapter = match instance
-            .request_adapter(&wgpu::RequestAdapterOptions::default())
-            .await
-        {
-            Some(a) => a,
-            None => {
-                let img = image::load_from_memory(bytes)?;
-                return Ok(Self::encode_image(&img));
-            }
-        };
-
-        let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
-            .await?;
-        let img = image::load_from_memory(bytes)?;
-        let data = img.to_rgb8();
-        let len = (data.width() * data.height() * 3) as u64;
-        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: None,
-            contents: &data,
-            usage: wgpu::BufferUsages::STORAGE,
-        });
-        let output = device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size: 12,
-            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: None,
-            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/avg.wgsl").into()),
-        });
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: None,
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: None,
-            layout: &bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: output.as_entire_binding(),
-                },
-            ],
-        });
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: None,
-            bind_group_layouts: &[&bind_group_layout],
-            push_constant_ranges: &[],
-        });
-        let compute_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: None,
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: "main",
-        });
-        let mut encoder =
-            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        {
-            let mut cpass =
-                encoder.begin_compute_pass(&wgpu::ComputePassDescriptor { label: None });
-            cpass.set_pipeline(&compute_pipeline);
-            cpass.set_bind_group(0, &bind_group, &[]);
-            cpass.dispatch_workgroups(len as u32 / 3, 1, 1);
+    /// Reduce a high dimensional vector with PCA.
+    pub fn pca_reduce(data: &[f32], new_dim: usize) -> Vec<f32> {
+        if new_dim == 0 || data.is_empty() {
+            return vec![];
         }
-        queue.submit(Some(encoder.finish()));
-        let buffer_slice = output.slice(..);
-        let (tx, rx) = futures::channel::oneshot::channel();
-
-        buffer_slice.map_async(wgpu::MapMode::Read, move |v| {
-            let _ = tx.send(v);
-        });
-
-        device.poll(wgpu::Maintain::Wait);
-        rx.await.unwrap()?;
-        let data = buffer_slice.get_mapped_range();
-        let vec = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
-        drop(data);
-        output.unmap();
-        Ok(vec)
+        if data.len() < new_dim {
+            return crate::semantic_compression::compress_embedding(data, new_dim);
+        }
+        let rows = data.len() - new_dim + 1;
+        let mut mat = Vec::with_capacity(rows * new_dim);
+        for i in 0..rows {
+            for j in 0..new_dim {
+                mat.push(data[i + j]);
+            }
+        }
+        let mut m = DMatrix::from_row_slice(rows, new_dim, &mat);
+        for c in 0..new_dim {
+            let mean: f32 = (0..rows).map(|r| m[(r, c)]).sum::<f32>() / rows as f32;
+            for r in 0..rows {
+                m[(r, c)] -= mean;
+            }
+        }
+        let vt = m.svd(true, true).v_t.unwrap();
+        let mut out = vec![0.0; new_dim];
+        for i in 0..new_dim {
+            let mut val = 0.0;
+            for j in 0..new_dim {
+                val += data[j] * vt[(i, j)];
+            }
+            out[i] = val;
+        }
+        out
     }
 
-    /// Encode raw image bytes (PNG/JPEG) into an embedding.
-    pub fn encode_bytes(bytes: &[u8]) -> Result<Vec<f32>> {
-        let img = image::load_from_memory(bytes)?;
-        Ok(Self::encode_image(&img))
+    /// Normalize a vector to unit length.
+    pub fn l2_normalize(v: &[f32]) -> Vec<f32> {
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            v.iter().map(|x| x / norm).collect()
+        } else {
+            v.to_vec()
+        }
     }
 
-    /// Encode image from a file path.
-    pub fn encode_path<P: AsRef<Path>>(path: P) -> Result<Vec<f32>> {
-        let img = image::open(path)?;
-        Ok(Self::encode_image(&img))
+    /// Estimate Shannon entropy of a vector.
+    pub fn estimate_entropy(v: &[f32]) -> f32 {
+        let sum: f32 = v.iter().map(|x| x.abs()).sum();
+        if sum == 0.0 {
+            return 0.0;
+        }
+        let mut ent = 0.0;
+        for x in v {
+            let p = x.abs() / sum;
+            if p > 0.0 {
+                ent -= p * p.log2();
+            }
+        }
+        ent
     }
 }
 
@@ -168,6 +176,6 @@ mod tests {
         let img = RgbImage::from_pixel(1, 1, image::Rgb([0, 0, 255]));
         let dynimg = DynamicImage::ImageRgb8(img);
         let emb = VisionEncoder::encode_image(&dynimg);
-        assert_eq!(emb.len(), 3);
+        assert_eq!(emb.len(), 8);
     }
 }

--- a/tests/unit/vision_encoder_tests.rs
+++ b/tests/unit/vision_encoder_tests.rs
@@ -3,13 +3,13 @@ use image::{DynamicImage, ImageOutputFormat, RgbImage};
 use std::io::Cursor;
 
 #[test]
-fn encode_image_returns_average_rgb() {
-    let img = RgbImage::from_fn(2, 2, |_, _| image::Rgb([255, 0, 0]));
+fn encode_image_basic_len_and_norm() {
+    let img = RgbImage::from_fn(4, 4, |x, y| image::Rgb([(x * 10) as u8, (y * 20) as u8, 0]));
     let img_dyn = DynamicImage::ImageRgb8(img);
     let emb = VisionEncoder::encode_image(&img_dyn);
-    assert!((emb[0] - 1.0).abs() < 1e-6);
-    assert!((emb[1]).abs() < 1e-6);
-    assert!((emb[2]).abs() < 1e-6);
+    assert_eq!(emb.len(), 8);
+    let norm = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!((norm - 1.0).abs() < 1e-6);
 }
 
 #[test]
@@ -22,10 +22,7 @@ fn encode_bytes_matches_encode_image() {
     let bytes = buf.into_inner();
     let emb_bytes = VisionEncoder::encode_bytes(&bytes).unwrap();
     let emb_image = VisionEncoder::encode_image(&DynamicImage::ImageRgb8(img));
-    assert_eq!(emb_bytes.len(), 3);
-    for (a, b) in emb_bytes.iter().zip(emb_image.iter()) {
-        assert!((a - b).abs() < 1e-6);
-    }
+    assert_eq!(emb_bytes, emb_image);
 }
 
 #[cfg(feature = "parallel")]
@@ -49,8 +46,36 @@ fn gpu_encoding_fallbacks() {
     let bytes = buf.into_inner();
     let gpu = pollster::block_on(VisionEncoder::encode_image_gpu(&bytes)).unwrap();
     let cpu = VisionEncoder::encode_image(&DynamicImage::ImageRgb8(img));
-    assert_eq!(gpu.len(), 3);
-    for (a, b) in gpu.iter().zip(cpu.iter()) {
-        assert!((a - b).abs() < 1e-3);
-    }
+    assert_eq!(gpu, cpu);
+}
+
+#[test]
+fn grid_output_shape() {
+    let mut img = RgbImage::new(2, 2);
+    img.put_pixel(0, 0, image::Rgb([255, 0, 0]));
+    img.put_pixel(1, 0, image::Rgb([0, 255, 0]));
+    img.put_pixel(0, 1, image::Rgb([0, 0, 255]));
+    img.put_pixel(1, 1, image::Rgb([255, 255, 255]));
+    let dynimg = DynamicImage::ImageRgb8(img);
+    let grid = VisionEncoder::encode_image_grid(&dynimg, 2);
+    assert_eq!(grid.len(), 12);
+    assert!((grid[0] - 1.0).abs() < 1e-6);
+    assert!((grid[4] - 1.0).abs() < 1e-6); // green patch
+}
+
+#[test]
+fn pca_reduce_dimension() {
+    let data: Vec<f32> = (0..48).map(|v| v as f32).collect();
+    let reduced = VisionEncoder::pca_reduce(&data, 4);
+    assert_eq!(reduced.len(), 4);
+}
+
+#[test]
+fn l2_norm_and_entropy() {
+    let v = vec![3.0, 4.0];
+    let normed = VisionEncoder::l2_normalize(&v);
+    let norm = normed.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!((norm - 1.0).abs() < 1e-6);
+    let ent = VisionEncoder::estimate_entropy(&normed);
+    assert!(ent > 0.0);
 }


### PR DESCRIPTION
## Summary
- implement patch grid mean and PCA-based encoder
- add normalization and entropy helpers
- revise encode_image_gpu to reuse CPU path
- update tests for new embedding logic

## Testing
- `cargo test --quiet`