### PR TITLE
Improve AureusBridge reasoning

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,3 +155,26 @@ use hipcortex::temporal_indexer::TemporalIndexer;
 * For integration/API details, see `docs/integration.md`.
 * To contribute, see `docs/contributing.md`.
 * For the roadmap and additional modules, see `docs/roadmap.md`.
+
+## 11. Reflexion Hypotheses Graph
+
+`AureusBridge` now tracks reasoning as a Bayesian hypothesis graph. Each reflexion step parses the LLM output into a `ReflexionHypothesis`:
+
+```json
+{
+  "text": "Sky appears blue",
+  "confidence": 0.72,
+  "evidence": ["sunlight scatters"]
+}
+```
+
+Edges between nodes mark support or refutation. Posterior confidence is
+computed via:
+
+```
+P(H|E) = P(E|H)P(H) / [P(E|H)P(H) + P(E|¬H)P(¬H)]
+```
+
+Nodes with posterior below the `prune_threshold` are automatically removed.
+Use `run_monte_carlo` to sample multiple hypotheses and select the highest mean
+confidence.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod effort;
 pub mod enhancement_advisor;
 #[cfg(feature = "gui")]
 pub mod gui;
+#[path = "modules/hypotheses_graph.rs"]
+pub mod hypotheses_graph;
 #[path = "modules/hypothesis_manager.rs"]
 pub mod hypothesis_manager;
 #[path = "modules/integration_layer.rs"]

--- a/src/modules/aureus_bridge.rs
+++ b/src/modules/aureus_bridge.rs
@@ -1,23 +1,43 @@
+use crate::hypotheses_graph::HypothesesGraph;
 /// Chain-of-Thought: belief -> evidence -> Bayesian update
 use crate::llm_clients::LLMClient;
 use crate::memory_record::{MemoryRecord, MemoryType};
 use crate::memory_store::MemoryStore;
 use crate::persistence::MemoryBackend;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
 
+/// Configuration options for the bridge.
 pub struct AureusConfig {
     pub enable_cot: bool,
+    /// Threshold for pruning low-confidence hypotheses.
+    pub prune_threshold: f32,
 }
 
 impl Default for AureusConfig {
     fn default() -> Self {
-        Self { enable_cot: false }
+        Self {
+            enable_cot: false,
+            prune_threshold: 0.2,
+        }
     }
+}
+
+/// Hypothesis produced by the reflexion loop.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReflexionHypothesis {
+    pub text: String,
+    pub confidence: f32, // 0.0..1.0
+    pub evidence: Vec<String>,
 }
 
 pub struct AureusBridge {
     loops: usize,
     llm: Option<Box<dyn LLMClient>>,
     config: AureusConfig,
+    graph: HypothesesGraph,
+    current: Option<Uuid>,
 }
 
 impl AureusBridge {
@@ -26,6 +46,8 @@ impl AureusBridge {
             loops: 0,
             llm: None,
             config: AureusConfig::default(),
+            graph: HypothesesGraph::new(),
+            current: None,
         }
     }
 
@@ -34,6 +56,8 @@ impl AureusBridge {
             loops: 0,
             llm: Some(client),
             config: AureusConfig::default(),
+            graph: HypothesesGraph::new(),
+            current: None,
         }
     }
 
@@ -45,6 +69,48 @@ impl AureusBridge {
         self.config = cfg;
     }
 
+    /// Bayesian update P(H|E) = P(E|H)P(H) / [P(E|H)P(H) + P(E|¬H)P(¬H)]
+    pub fn update_belief(&self, prior: f32, likelihood: f32) -> f32 {
+        let num = prior * likelihood;
+        let denom = num + (1.0 - prior) * (1.0 - likelihood);
+        if denom == 0.0 {
+            0.0
+        } else {
+            num / denom
+        }
+    }
+
+    fn parse_hypothesis(&self, resp: &str) -> (ReflexionHypothesis, bool) {
+        let mut lines = resp.lines();
+        let text = lines.next().unwrap_or("").trim().to_string();
+        let mut confidence = 0.5f32;
+        let mut evidence = Vec::new();
+        let mut supports = true;
+        for line in lines {
+            let l = line.trim();
+            if let Some(rest) = l.strip_prefix("Confidence:") {
+                if let Ok(v) = rest.trim().parse::<f32>() {
+                    confidence = v;
+                }
+            } else if l.to_lowercase().contains("refute") {
+                supports = false;
+            } else if l.to_lowercase().contains("support") {
+                supports = true;
+            } else if !l.is_empty() {
+                evidence.push(l.to_string());
+            }
+        }
+        (
+            ReflexionHypothesis {
+                text,
+                confidence,
+                evidence,
+            },
+            supports,
+        )
+    }
+
+    /// Run one reflexion pass.
     pub fn reflexion_loop<B: MemoryBackend>(&mut self, context: &str, store: &mut MemoryStore<B>) {
         self.loops += 1;
         if let Some(client) = &self.llm {
@@ -54,12 +120,27 @@ impl AureusBridge {
                 context.to_string()
             };
             let response = client.generate_response(&prompt);
+            let (mut hyp, supports) = self.parse_hypothesis(&response);
+            let prior = self
+                .current
+                .and_then(|id| self.graph.get_hypothesis(id))
+                .map(|h| h.confidence)
+                .unwrap_or(0.5);
+            hyp.confidence = self.update_belief(prior, hyp.confidence);
+            let node_id = self
+                .graph
+                .add_hypothesis(hyp.clone(), self.current, supports);
+            self.current = Some(node_id);
+            self.graph.prune_low_confidence(self.config.prune_threshold);
             let record = MemoryRecord::new(
                 MemoryType::Reflexion,
                 "aureus".into(),
                 "llm".into(),
-                response,
-                serde_json::json!({}),
+                hyp.text.clone(),
+                serde_json::json!({
+                    "confidence": hyp.confidence,
+                    "evidence": hyp.evidence,
+                }),
             );
             let _ = store.add(record);
         } else {
@@ -73,6 +154,39 @@ impl AureusBridge {
 
     pub fn reset(&mut self) {
         self.loops = 0;
+        self.current = None;
+        self.graph = HypothesesGraph::new();
+    }
+
+    /// Run N reflexion passes and return the dominant hypothesis by mean confidence.
+    pub fn run_monte_carlo<B: MemoryBackend>(
+        &mut self,
+        context: &str,
+        store: &mut MemoryStore<B>,
+        samples: usize,
+    ) -> ReflexionHypothesis {
+        let mut scores: HashMap<String, Vec<f32>> = HashMap::new();
+        for _ in 0..samples {
+            self.reflexion_loop(context, store);
+            if let Some(id) = self.current {
+                if let Some(h) = self.graph.get_hypothesis(id) {
+                    scores.entry(h.text.clone()).or_default().push(h.confidence);
+                }
+            }
+        }
+        let mut best = ReflexionHypothesis {
+            text: String::new(),
+            confidence: 0.0,
+            evidence: Vec::new(),
+        };
+        for (text, vals) in scores {
+            let mean = vals.iter().copied().sum::<f32>() / vals.len() as f32;
+            if mean > best.confidence {
+                best.confidence = mean;
+                best.text = text;
+            }
+        }
+        best
     }
 }
 
@@ -80,6 +194,14 @@ impl AureusBridge {
 mod tests {
     use super::*;
     use crate::llm_clients::mock::MockClient;
+
+    #[test]
+    fn bayesian_update_math() {
+        let bridge = AureusBridge::new();
+        let post = bridge.update_belief(0.6, 0.8);
+        let expected = (0.6 * 0.8) / ((0.6 * 0.8) + ((1.0 - 0.6) * (1.0 - 0.8)));
+        approx::assert_abs_diff_eq!(post, expected, epsilon = 1e-6);
+    }
 
     #[test]
     fn run_loop_increments_counter() {

--- a/src/modules/hypotheses_graph.rs
+++ b/src/modules/hypotheses_graph.rs
@@ -1,0 +1,93 @@
+use petgraph::algo::is_cyclic_directed;
+use petgraph::graph::{DiGraph, NodeIndex};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::aureus_bridge::ReflexionHypothesis;
+
+/// Node in the reflexion hypotheses graph.
+pub struct HypothesisNode {
+    pub id: Uuid,
+    pub hypothesis: ReflexionHypothesis,
+    pub children: Vec<Uuid>,
+    pub supports: bool,
+}
+
+/// Directed acyclic graph of hypotheses.
+pub struct HypothesesGraph {
+    graph: DiGraph<HypothesisNode, bool>,
+    map: HashMap<Uuid, NodeIndex>,
+}
+
+impl HypothesesGraph {
+    pub fn new() -> Self {
+        Self {
+            graph: DiGraph::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    /// Add a hypothesis node, optionally connecting to a parent.
+    pub fn add_hypothesis(
+        &mut self,
+        hypothesis: ReflexionHypothesis,
+        parent: Option<Uuid>,
+        supports: bool,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        let node = HypothesisNode {
+            id,
+            hypothesis: hypothesis.clone(),
+            children: Vec::new(),
+            supports,
+        };
+        let idx = self.graph.add_node(node);
+        self.map.insert(id, idx);
+        if let Some(pid) = parent {
+            if let Some(pidx) = self.map.get(&pid).cloned() {
+                self.graph.add_edge(pidx, idx, supports);
+                if let Some(pn) = self.graph.node_weight_mut(pidx) {
+                    pn.children.push(id);
+                }
+            }
+        }
+        id
+    }
+
+    /// Retrieve a hypothesis by id.
+    pub fn get_hypothesis(&self, id: Uuid) -> Option<&ReflexionHypothesis> {
+        self.map
+            .get(&id)
+            .and_then(|idx| self.graph.node_weight(*idx))
+            .map(|n| &n.hypothesis)
+    }
+
+    /// Mutable access to a hypothesis.
+    pub fn get_hypothesis_mut(&mut self, id: Uuid) -> Option<&mut ReflexionHypothesis> {
+        if let Some(idx) = self.map.get(&id).cloned() {
+            self.graph.node_weight_mut(idx).map(|n| &mut n.hypothesis)
+        } else {
+            None
+        }
+    }
+
+    /// Remove nodes with confidence below threshold.
+    pub fn prune_low_confidence(&mut self, threshold: f32) {
+        let remove: Vec<NodeIndex> = self
+            .graph
+            .node_indices()
+            .filter(|idx| self.graph[*idx].hypothesis.confidence < threshold)
+            .collect();
+        for idx in remove {
+            if let Some(node) = self.graph.node_weight(idx) {
+                self.map.remove(&node.id);
+            }
+            self.graph.remove_node(idx);
+        }
+    }
+
+    /// Check if the graph contains cycles.
+    pub fn has_cycles(&self) -> bool {
+        is_cyclic_directed(&self.graph)
+    }
+}

--- a/tests/integration/llm_integration_tests.rs
+++ b/tests/integration/llm_integration_tests.rs
@@ -9,7 +9,10 @@ fn reflexion_loop_stores_response() {
     let mut store = MemoryStore::new(path).unwrap();
     store.clear();
     let mut bridge = AureusBridge::with_client(Box::new(MockClient));
-    bridge.configure(AureusConfig { enable_cot: true });
+    bridge.configure(AureusConfig {
+        enable_cot: true,
+        prune_threshold: 0.2,
+    });
     bridge.reflexion_loop("context", &mut store);
     assert_eq!(store.all().len(), 1);
     std::fs::remove_file(path).ok();

--- a/tests/integration/uat_tests.rs
+++ b/tests/integration/uat_tests.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
+use hipcortex::decay::DecayType;
 use hipcortex::memory_store::MemoryStore;
 use hipcortex::symbolic_store::SymbolicStore;
 use hipcortex::temporal_indexer::{TemporalIndexer, TemporalTrace};
-use hipcortex::decay::DecayType;
 
 #[test]
 fn travelg3n_store_and_retrieve_city() {
@@ -23,7 +23,9 @@ fn travelg3n_store_and_retrieve_city() {
         relevance: 1.0,
         decay_factor: 0.5,
         last_access: SystemTime::now(),
-        decay_type: DecayType::Exponential { half_life: Duration::from_secs(1) },
+        decay_type: DecayType::Exponential {
+            half_life: Duration::from_secs(1),
+        },
     };
     indexer.insert(trace);
 
@@ -48,7 +50,10 @@ fn athena_chain_of_thought_reasoning() {
     let path = "test_uat_cot.jsonl";
     let _ = std::fs::remove_file(path);
     let mut aureus = AureusBridge::with_client(Box::new(MockClient));
-    aureus.configure(AureusConfig { enable_cot: true });
+    aureus.configure(AureusConfig {
+        enable_cot: true,
+        prune_threshold: 0.2,
+    });
     let mut store = MemoryStore::new(path).unwrap();
     store.clear();
     aureus.reflexion_loop("ctx", &mut store);
@@ -79,7 +84,9 @@ fn user_store_reasoning_trace() {
         relevance: 1.0,
         decay_factor: 0.5,
         last_access: SystemTime::now(),
-        decay_type: DecayType::Exponential { half_life: Duration::from_secs(1) },
+        decay_type: DecayType::Exponential {
+            half_life: Duration::from_secs(1),
+        },
     };
     indexer.insert(trace);
 

--- a/tests/unit/aureus_bridge_tests.rs
+++ b/tests/unit/aureus_bridge_tests.rs
@@ -1,48 +1,95 @@
 use hipcortex::aureus_bridge::AureusBridge;
-use hipcortex::memory_store::MemoryStore;
-use hipcortex::aureus_bridge::AureusConfig;
+use hipcortex::hypotheses_graph::HypothesesGraph;
 use hipcortex::llm_clients::mock::MockClient;
+use hipcortex::memory_store::MemoryStore;
 
-#[test]
-fn aureus_bridge_reflexion_loop() {
-    let mut aureus = AureusBridge::new();
-    let mut store = MemoryStore::new("test_aureus.jsonl").unwrap();
-    store.clear();
-    aureus.reflexion_loop("ctx", &mut store);
+struct SeqClient {
+    responses: Vec<String>,
+    idx: std::sync::Mutex<usize>,
+}
+
+impl SeqClient {
+    fn new(responses: Vec<String>) -> Self {
+        Self {
+            responses,
+            idx: std::sync::Mutex::new(0),
+        }
+    }
+}
+
+impl hipcortex::llm_clients::LLMClient for SeqClient {
+    fn generate_response(&self, _prompt: &str) -> String {
+        let mut i = self.idx.lock().unwrap();
+        let resp = self.responses[*i].clone();
+        if *i + 1 < self.responses.len() {
+            *i += 1;
+        }
+        resp
+    }
 }
 
 #[test]
-fn aureus_bridge_multiple_reflexion_loops() {
-    let mut aureus = AureusBridge::new();
-    let mut store = MemoryStore::new("test_aureus.jsonl").unwrap();
-    store.clear();
-    aureus.reflexion_loop("ctx", &mut store);
-    aureus.reflexion_loop("ctx", &mut store);
+fn bayesian_update() {
+    let bridge = AureusBridge::new();
+    let post = bridge.update_belief(0.6, 0.8);
+    let expected = (0.6 * 0.8) / ((0.6 * 0.8) + ((1.0 - 0.6) * (1.0 - 0.8)));
+    approx::assert_abs_diff_eq!(post, expected, epsilon = 1e-6);
 }
 
 #[test]
-fn aureus_bridge_loop_counter() {
-    let mut aureus = AureusBridge::new();
-    let mut store = MemoryStore::new("test_aureus.jsonl").unwrap();
-    store.clear();
-    aureus.reflexion_loop("ctx", &mut store);
-    aureus.reflexion_loop("ctx", &mut store);
-    assert_eq!(aureus.loops_run(), 2);
-    aureus.reset();
-    assert_eq!(aureus.loops_run(), 0);
+fn graph_no_cycles() {
+    let mut graph = HypothesesGraph::new();
+    use hipcortex::aureus_bridge::ReflexionHypothesis;
+    let a = graph.add_hypothesis(
+        ReflexionHypothesis {
+            text: "A".into(),
+            confidence: 0.5,
+            evidence: vec![],
+        },
+        None,
+        true,
+    );
+    graph.add_hypothesis(
+        ReflexionHypothesis {
+            text: "B".into(),
+            confidence: 0.5,
+            evidence: vec![],
+        },
+        Some(a),
+        true,
+    );
+    assert!(!graph.has_cycles());
 }
 
 #[test]
-fn aureus_bridge_chain_of_thought_prompt() {
-    let path = "test_aureus_cot.jsonl";
+fn monte_carlo_selects_best() {
+    let responses: Vec<String> = vec![
+        "HypA\nConfidence: 0.4".to_string(),
+        "HypB\nConfidence: 0.8".to_string(),
+        "HypB\nConfidence: 0.9".to_string(),
+    ];
+    let client = SeqClient::new(responses);
+    let mut bridge = AureusBridge::with_client(Box::new(client));
+    let path = "mc_test.jsonl";
     let _ = std::fs::remove_file(path);
-    let mut aureus = AureusBridge::with_client(Box::new(MockClient));
-    aureus.configure(AureusConfig { enable_cot: true });
     let mut store = MemoryStore::new(path).unwrap();
     store.clear();
-    aureus.reflexion_loop("ctx", &mut store);
-    let records = store.all();
-    assert_eq!(records.len(), 1);
-    assert!(records[0].target.contains("Think step by step."));
+    let best = bridge.run_monte_carlo("ctx", &mut store, 3);
+    assert_eq!(best.text, "HypB");
+    assert!(best.confidence > 0.8);
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn reflexion_record_contains_confidence() {
+    let mut bridge = AureusBridge::with_client(Box::new(MockClient));
+    let path = "reflex.jsonl";
+    let _ = std::fs::remove_file(path);
+    let mut store = MemoryStore::new(path).unwrap();
+    store.clear();
+    bridge.reflexion_loop("ctx", &mut store);
+    let recs = store.all();
+    assert_eq!(recs.len(), 1);
+    assert!(recs[0].metadata.get("confidence").is_some());
     std::fs::remove_file(path).ok();
 }


### PR DESCRIPTION
## Summary
- implement ReflexionHypothesis and Bayesian belief update
- maintain hypotheses graph and pruning
- add Monte Carlo sampling to AureusBridge
- document reflexion hypotheses in usage guide
- extend integration tests with prune threshold
- add unit tests for reasoning updates

## Testing
- `cargo test`