### PR TITLE
Add probabilistic HypothesisManager

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,3 +178,22 @@ P(H|E) = P(E|H)P(H) / [P(E|H)P(H) + P(E|¬H)P(¬H)]
 Nodes with posterior below the `prune_threshold` are automatically removed.
 Use `run_monte_carlo` to sample multiple hypotheses and select the highest mean
 confidence.
+
+## 12. HypothesisManager Example
+
+The `HypothesisManager` manages a tree of hypotheses with Bayesian probabilities. Nodes with low probability can be pruned automatically.
+
+```rust
+use hipcortex::hypothesis_manager::HypothesisManager;
+
+let mut mgr = HypothesisManager::new();
+let root = mgr.add_root("start", 0.6);
+mgr.add_child(root, "option_a", 0.7);
+mgr.add_child(root, "option_b", 0.4);
+
+let best = mgr.best_path();
+for h in best { println!("{} : {}", h.state, h.probability); }
+
+mgr.export_dot("hypotheses.dot");
+```
+

--- a/src/modules/hypothesis_manager.rs
+++ b/src/modules/hypothesis_manager.rs
@@ -1,55 +1,222 @@
-/// Chain-of-Thought: add root -> branch hypotheses -> backtrack
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::Write;
 
-/// Maintains a quantized tree of hypothesis states for backtracking.
+/// Simple hypothesis node with associated probability.
+#[derive(Clone)]
+pub struct Hypothesis<T> {
+    pub state: T,
+    pub probability: f32, // 0.0..=1.0
+}
+
+/// Maintains a forest of hypotheses with Bayesian updates and pruning.
 #[derive(Default)]
 pub struct HypothesisManager<T> {
-    states: HashMap<usize, T>,
-    parent: HashMap<usize, usize>,
+    nodes: HashMap<usize, Hypothesis<T>>, // id -> hypothesis
+    parent: HashMap<usize, usize>,        // child -> parent
     counter: usize,
 }
 
 impl<T: Clone> HypothesisManager<T> {
+    /// Create a new empty manager.
     pub fn new() -> Self {
         Self {
-            states: HashMap::new(),
+            nodes: HashMap::new(),
             parent: HashMap::new(),
             counter: 0,
         }
     }
 
-    /// Add a root state, returning its id.
-    pub fn add_root(&mut self, state: T) -> usize {
+    /// Standard Bayesian probability update.
+    ///
+    /// `prior` is the prior probability of the hypothesis,
+    /// `likelihood` is the probability of the evidence assuming the hypothesis.
+    /// The complement probability P(E|¬H) is assumed to be `1 - likelihood`.
+    pub fn update_probability(&self, prior: f32, likelihood: f32) -> f32 {
+        (prior * likelihood) / ((prior * likelihood) + ((1.0 - prior) * (1.0 - likelihood)))
+    }
+
+    /// Add a root hypothesis and return its unique id.
+    pub fn add_root(&mut self, state: T, probability: f32) -> usize {
         self.counter += 1;
-        self.states.insert(self.counter, state);
+        self.nodes
+            .insert(self.counter, Hypothesis { state, probability });
         self.counter
     }
 
-    /// Add a child state referencing a parent id.
-    pub fn add_child(&mut self, parent: usize, state: T) -> usize {
+    /// Add a child hypothesis refining a parent given new evidence likelihood.
+    pub fn add_child(&mut self, parent: usize, state: T, likelihood: f32) -> usize {
+        let parent_prob = self
+            .nodes
+            .get(&parent)
+            .expect("parent not found")
+            .probability;
         self.counter += 1;
-        self.states.insert(self.counter, state);
+        let prob = self.update_probability(parent_prob, likelihood);
+        self.nodes.insert(
+            self.counter,
+            Hypothesis {
+                state,
+                probability: prob,
+            },
+        );
         self.parent.insert(self.counter, parent);
+        self.normalize_children(parent);
         self.counter
     }
 
-    pub fn get(&self, id: usize) -> Option<&T> {
-        self.states.get(&id)
+    /// Retrieve hypothesis by id.
+    pub fn get(&self, id: usize) -> Option<&Hypothesis<T>> {
+        self.nodes.get(&id)
     }
 
-    /// Backtrack from given id to root, returning the path of states.
-    pub fn backtrack(&self, id: usize) -> Vec<&T> {
+    /// Return ids of all children for a parent.
+    fn children_of(&self, parent: usize) -> Vec<usize> {
+        self.parent
+            .iter()
+            .filter_map(|(c, p)| if *p == parent { Some(*c) } else { None })
+            .collect()
+    }
+
+    /// Normalize sibling probabilities so they sum to the parent probability.
+    fn normalize_children(&mut self, parent: usize) {
+        let child_ids = self.children_of(parent);
+        if child_ids.is_empty() {
+            return;
+        }
+        let sum: f32 = child_ids
+            .iter()
+            .map(|id| self.nodes.get(id).unwrap().probability)
+            .sum();
+        if sum == 0.0 {
+            return;
+        }
+        let parent_prob = self.nodes.get(&parent).unwrap().probability;
+        for id in child_ids {
+            if let Some(node) = self.nodes.get_mut(&id) {
+                node.probability = node.probability / sum * parent_prob;
+            }
+        }
+    }
+
+    /// Backtrack from a hypothesis to its root, returning the path of nodes.
+    pub fn backtrack(&self, id: usize) -> Vec<&Hypothesis<T>> {
         let mut cur = id;
         let mut path = Vec::new();
-        while let Some(state) = self.states.get(&cur) {
-            path.push(state);
-            if let Some(p) = self.parent.get(&cur) {
-                cur = *p;
+        while let Some(node) = self.nodes.get(&cur) {
+            path.push(node);
+            if let Some(p) = self.parent.get(&cur).cloned() {
+                cur = p;
             } else {
                 break;
             }
         }
         path.reverse();
         path
+    }
+
+    /// Remove a node and all of its descendants.
+    fn remove_subtree(&mut self, id: usize) {
+        let children = self.children_of(id);
+        for c in children {
+            self.remove_subtree(c);
+        }
+        self.nodes.remove(&id);
+        self.parent.remove(&id);
+    }
+
+    /// Prune all hypotheses with probability below `threshold`.
+    pub fn prune_low_probability(&mut self, threshold: f32) {
+        let ids: Vec<usize> = self
+            .nodes
+            .iter()
+            .filter_map(|(id, h)| {
+                if h.probability < threshold {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let mut affected = HashSet::new();
+        for id in ids {
+            if let Some(p) = self.parent.get(&id).cloned() {
+                affected.insert(p);
+            }
+            self.remove_subtree(id);
+        }
+        for p in affected {
+            self.normalize_children(p);
+        }
+    }
+
+    fn is_leaf(&self, id: usize) -> bool {
+        !self.parent.values().any(|p| *p == id)
+    }
+
+    /// Find path ending in the leaf with highest probability.
+    pub fn best_path(&self) -> Vec<&Hypothesis<T>> {
+        let leaf = self
+            .nodes
+            .keys()
+            .filter(|id| self.is_leaf(**id))
+            .max_by(|a, b| {
+                self.nodes[a]
+                    .probability
+                    .partial_cmp(&self.nodes[b].probability)
+                    .unwrap()
+            });
+        if let Some(id) = leaf {
+            self.backtrack(*id)
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Return the top `n` leaf paths ordered by probability.
+    pub fn top_n_paths(&self, n: usize) -> Vec<Vec<&Hypothesis<T>>> {
+        let mut leaves: Vec<(usize, f32)> = self
+            .nodes
+            .iter()
+            .filter(|(id, _)| self.is_leaf(**id))
+            .map(|(id, h)| (*id, h.probability))
+            .collect();
+        leaves.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        leaves
+            .into_iter()
+            .take(n)
+            .map(|(id, _)| self.backtrack(id))
+            .collect()
+    }
+
+    /// Export the hypothesis tree in Graphviz `.dot` format.
+    pub fn export_dot(&self, filename: &str) {
+        let mut file = File::create(filename).expect("cannot create dot file");
+        writeln!(file, "digraph Hypotheses {{").unwrap();
+        for (id, node) in &self.nodes {
+            writeln!(
+                file,
+                "    {} [label=\"{}:{:.3}\"];",
+                id, id, node.probability
+            )
+            .unwrap();
+        }
+        for (child, parent) in &self.parent {
+            writeln!(file, "    {} -> {};", parent, child).unwrap();
+        }
+        writeln!(file, "}}").unwrap();
+    }
+
+    /// Ensure every parent exists and the structure contains no cycles.
+    pub fn assert_tree_validity(&self) {
+        for (&_child, &parent) in &self.parent {
+            assert!(self.nodes.contains_key(&parent));
+            let mut seen = HashSet::new();
+            let mut cur = parent;
+            while let Some(p) = self.parent.get(&cur).cloned() {
+                assert!(seen.insert(cur), "cycle detected");
+                cur = p;
+            }
+        }
     }
 }

--- a/tests/unit/hypothesis_manager_tests.rs
+++ b/tests/unit/hypothesis_manager_tests.rs
@@ -1,10 +1,54 @@
+use approx::assert_abs_diff_eq;
 use hipcortex::hypothesis_manager::HypothesisManager;
+use std::fs;
+use tempfile::NamedTempFile;
 
 #[test]
-fn add_and_backtrack() {
+fn update_probability_math() {
+    let m: HypothesisManager<()> = HypothesisManager::new();
+    let posterior = m.update_probability(0.5, 0.8);
+    assert_abs_diff_eq!(posterior, 0.8, epsilon = 1e-6);
+}
+
+#[test]
+fn best_path_and_backtrack() {
     let mut m = HypothesisManager::new();
-    let root = m.add_root(1);
-    let child = m.add_child(root, 2);
-    let path = m.backtrack(child);
-    assert_eq!(path, vec![&1, &2]);
+    let root = m.add_root("root", 0.6);
+    let a = m.add_child(root, "a", 0.7);
+    let _b = m.add_child(root, "b", 0.4);
+    // best leaf should be `a`
+    let best = m.best_path();
+    assert_eq!(
+        best.iter().map(|h| h.state).collect::<Vec<_>>(),
+        vec!["root", "a"]
+    );
+    // backtracking from a
+    let path = m.backtrack(a);
+    assert_eq!(
+        path.iter().map(|h| h.state).collect::<Vec<_>>(),
+        vec!["root", "a"]
+    );
+}
+
+#[test]
+fn pruning_removes_low_probability() {
+    let mut m = HypothesisManager::new();
+    let root = m.add_root("root", 0.6);
+    let _good = m.add_child(root, "good", 0.7);
+    let bad = m.add_child(root, "bad", 0.1);
+    m.prune_low_probability(0.2);
+    assert!(m.get(bad).is_none());
+    assert!(m.get(root).is_some());
+}
+
+#[test]
+fn export_generates_dot() {
+    let mut m = HypothesisManager::new();
+    let root = m.add_root("root", 0.5);
+    m.add_child(root, "child", 0.6);
+    let file = NamedTempFile::new().unwrap();
+    let path = file.path().to_path_buf();
+    m.export_dot(path.to_str().unwrap());
+    let contents = fs::read_to_string(path).unwrap();
+    assert!(contents.contains("digraph"));
 }


### PR DESCRIPTION
## Summary
- implement Bayesian `HypothesisManager` with pruning, ranking and export
- document usage of the manager
- test probability math, pruning, and graph export

## Testing
- `cargo test --no-fail-fast`