### PR TITLE
Implement collapse metrics with decay models

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,22 @@ cargo run --example plugin_host --features plugin
 
 This runs `examples/plugin_host.rs` which loads a tiny WAT module and prints the returned value.
 
+### Effort & Confidence Example
+
+Measure reasoning effort and decay confidence dynamically:
+
+```rust
+use hipcortex::effort::{EffortEvaluator, ConfidenceRegulator};
+
+let mut eval = EffortEvaluator::new();
+eval.record(5); // weighted cost
+
+let mut conf = ConfidenceRegulator::new();
+conf.decay_exponential(0.2);
+
+println!("Collapse: {}", eval.collapse_score(conf.confidence()));
+```
+
 ## 5. VS Code Setup
 
 * Open project root in VS Code.

--- a/src/modules/effort.rs
+++ b/src/modules/effort.rs
@@ -9,13 +9,39 @@ impl EffortEvaluator {
         Self { effort: 0 }
     }
 
-    /// Record a reasoning step.
-    pub fn record(&mut self) {
-        self.effort += 1;
+    /// Record a reasoning step with an associated cost.
+    ///
+    /// The cost can represent token usage, elapsed time, or any unit of
+    /// computational effort. Larger costs increase the evaluator's effort
+    /// counter proportionally.
+    pub fn record(&mut self, cost: usize) {
+        self.effort += cost;
+    }
+
+    /// Convenience method for recording a single unit of effort.
+    pub fn record_step(&mut self) {
+        self.record(1);
     }
 
     pub fn effort(&self) -> usize {
         self.effort
+    }
+
+    /// Collapse score combines effort and confidence into a bounded metric.
+    ///
+    /// The formula is:
+    /// `collapse_score = normalized_effort * (1 - confidence)`
+    /// where `normalized_effort = effort / (effort + 1)` ensures the result
+    /// remains in `[0,1]`.
+    pub fn collapse_score(&self, confidence: f32) -> f32 {
+        let normalized_effort = self.effort as f32 / (self.effort as f32 + 1.0);
+        normalized_effort * (1.0 - confidence.clamp(0.0, 1.0))
+    }
+
+    /// Returns true if the collapse score is greater than or equal to
+    /// `threshold`.
+    pub fn is_collapse_imminent(&self, confidence: f32, threshold: f32) -> bool {
+        self.collapse_score(confidence) >= threshold
     }
 }
 
@@ -30,8 +56,21 @@ impl ConfidenceRegulator {
         Self { confidence: 1.0 }
     }
 
+    /// Linear decay: `C_new = (C_old - amount).clamp(0, 1)`.
     pub fn decay(&mut self, amount: f32) {
-        self.confidence = (self.confidence - amount).max(0.0);
+        self.confidence = (self.confidence - amount).clamp(0.0, 1.0);
+    }
+
+    /// Exponential decay: `C_new = C_old * (1 - rate)`.
+    pub fn decay_exponential(&mut self, decay_rate: f32) {
+        self.confidence *= (1.0 - decay_rate).max(0.0);
+        self.confidence = self.confidence.clamp(0.0, 1.0);
+    }
+
+    /// Logarithmic decay: `C_new = C_old * 1/(1 + factor)`.
+    pub fn decay_log(&mut self, decay_factor: f32) {
+        self.confidence *= (1.0 / (1.0 + decay_factor)).max(0.0);
+        self.confidence = self.confidence.clamp(0.0, 1.0);
     }
 
     pub fn confidence(&self) -> f32 {

--- a/tests/integration/effort_confidence_sit.rs
+++ b/tests/integration/effort_confidence_sit.rs
@@ -1,0 +1,17 @@
+use hipcortex::effort::{ConfidenceRegulator, EffortEvaluator};
+
+#[test]
+fn collapse_score_integration_flow() {
+    let mut eval = EffortEvaluator::new();
+    let mut reg = ConfidenceRegulator::new();
+
+    // Record multiple reasoning steps with varied cost.
+    eval.record(2);
+    reg.decay_exponential(0.1);
+    eval.record(3);
+    reg.decay_log(0.5);
+
+    let score = eval.collapse_score(reg.confidence());
+    assert!(score > 0.0 && score <= 1.0);
+    assert!(eval.is_collapse_imminent(reg.confidence(), 0.1));
+}

--- a/tests/integration/effort_confidence_uat.rs
+++ b/tests/integration/effort_confidence_uat.rs
@@ -1,0 +1,17 @@
+use hipcortex::effort::{ConfidenceRegulator, EffortEvaluator};
+
+#[test]
+fn user_tracks_effort_and_confidence() {
+    let mut eval = EffortEvaluator::new();
+    let mut reg = ConfidenceRegulator::new();
+
+    // Simulate a user reasoning session with incremental decay.
+    for cost in [1, 2, 3] {
+        eval.record(cost);
+        reg.decay(0.15);
+    }
+
+    let score = eval.collapse_score(reg.confidence());
+    assert!(score >= 0.0 && score <= 1.0);
+    assert!(eval.is_collapse_imminent(reg.confidence(), 0.3));
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,11 +3,17 @@ mod conversation_memory_sit;
 mod conversation_memory_uat;
 mod edge_workflow_sit;
 mod edge_workflow_uat;
+mod effort_confidence_sit;
+mod effort_confidence_uat;
 #[cfg(feature = "grpc-server")]
 mod grpc_tests;
 mod humanoid_perception_uat;
 mod integration_tests;
 mod llm_integration_tests;
+#[cfg(all(feature = "web-server", feature = "grpc-server"))]
+mod mcp_server_sit;
+#[cfg(all(feature = "web-server", feature = "grpc-server"))]
+mod mcp_server_uat;
 mod openmanus_integration_sit;
 mod plugin_host_sit;
 mod plugin_host_uat;
@@ -24,7 +30,3 @@ mod test_end_to_end;
 mod uat_tests;
 mod world_model_cli_sit;
 mod world_model_uat;
-#[cfg(all(feature = "web-server", feature = "grpc-server"))]
-mod mcp_server_sit;
-#[cfg(all(feature = "web-server", feature = "grpc-server"))]
-mod mcp_server_uat;

--- a/tests/unit/effort_tests.rs
+++ b/tests/unit/effort_tests.rs
@@ -1,11 +1,46 @@
 use hipcortex::effort::{ConfidenceRegulator, EffortEvaluator};
 
 #[test]
-fn effort_and_confidence() {
+fn cost_weighted_effort() {
     let mut eval = EffortEvaluator::new();
-    let mut conf = ConfidenceRegulator::new();
-    eval.record();
-    conf.decay(0.1);
-    assert_eq!(eval.effort(), 1);
-    assert!(conf.confidence() < 1.0);
+    eval.record(2);
+    eval.record(3);
+    assert_eq!(eval.effort(), 5);
+}
+
+#[test]
+fn confidence_decay_models() {
+    let mut reg = ConfidenceRegulator::new();
+    reg.decay(0.2);
+    assert!((reg.confidence() - 0.8).abs() < 1e-6);
+    reg.decay_exponential(0.5); // 0.8 * 0.5
+    assert!((reg.confidence() - 0.4).abs() < 1e-6);
+    reg.decay_log(1.0); // 0.4 * 1/(1+1) = 0.2
+    assert!((reg.confidence() - 0.2).abs() < 1e-6);
+}
+
+#[test]
+fn confidence_never_negative() {
+    let mut reg = ConfidenceRegulator::new();
+    reg.decay(2.0);
+    assert_eq!(reg.confidence(), 0.0);
+    reg.decay(1.0);
+    reg.decay_exponential(0.5);
+    reg.decay_log(10.0);
+    assert_eq!(reg.confidence(), 0.0);
+}
+
+#[test]
+fn collapse_score_bounds_and_threshold() {
+    let mut eval = EffortEvaluator::new();
+    let conf = 1.0;
+    let score = eval.collapse_score(conf);
+    assert!((score - 0.0).abs() < 1e-6);
+    assert!(!eval.is_collapse_imminent(conf, 0.5));
+
+    eval.record(10);
+    let conf = 0.2;
+    let score = eval.collapse_score(conf);
+    assert!(score >= 0.0 && score <= 1.0);
+    assert!(eval.is_collapse_imminent(conf, 0.1));
 }


### PR DESCRIPTION
## Summary
- extend EffortEvaluator with cost weights, collapse score and threshold check
- add exponential and logarithmic confidence decay
- document usage of new metrics
- test weighted effort, decay math and collapse score
- integrate new collapse metric into SIT and UAT test suites

## Testing
- `cargo test --quiet`