### PR TITLE
Add OpenManus and MCP protocol bridges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,10 @@ pub mod hypothesis_manager;
 pub mod integration_layer;
 pub mod knowledge_export;
 pub mod llm_clients;
+#[path = "modules/openmanus_bridge.rs"]
+pub mod openmanus_bridge;
+#[path = "modules/mcp_bridge.rs"]
+pub mod mcp_bridge;
 pub mod markov;
 pub mod memory;
 pub mod memory_cli;

--- a/src/modules/integration_layer.rs
+++ b/src/modules/integration_layer.rs
@@ -1,6 +1,8 @@
 use crate::aureus_bridge::AureusBridge;
 use crate::llm_clients::LLMClient;
 use crate::memory_store::MemoryStore;
+use crate::openmanus_bridge;
+use crate::mcp_bridge;
 use crate::persistence::MemoryBackend;
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -90,6 +92,28 @@ impl IntegrationLayer {
         }
     }
 
+    pub fn handle_openmanus(&self, key: &str, payload: &str) {
+        match openmanus_bridge::decode_request(payload) {
+            Ok(p) => {
+                if let Some(text) = p.text {
+                    self.send_message(key, &text);
+                }
+            }
+            Err(_) => println!("[IntegrationLayer] invalid OpenManus payload"),
+        }
+    }
+
+    pub fn handle_mcp(&self, key: &str, payload: &str) {
+        match mcp_bridge::decode_request(payload) {
+            Ok(p) => {
+                if let Some(text) = p.text {
+                    self.send_message(key, &text);
+                }
+            }
+            Err(_) => println!("[IntegrationLayer] invalid MCP payload"),
+        }
+    }
+
     pub fn invoke_llm(&self, key: &str, prompt: &str) -> Option<String> {
         if !self.authenticated(key) {
             println!("[IntegrationLayer] unauthorized");
@@ -113,6 +137,40 @@ impl IntegrationLayer {
 
     pub fn is_connected(&self) -> bool {
         self.connected
+    }
+
+    #[cfg(feature = "web-server")]
+    pub async fn run_uat_server(addr: std::net::SocketAddr) {
+        use axum::{routing::post, Json, Router};
+
+        async fn translate(Json(payload): Json<serde_json::Value>) -> Json<serde_json::Value> {
+            let json = serde_json::to_string(&payload).unwrap();
+            if payload.get("role").is_some() {
+                match openmanus_bridge::decode_request(&json) {
+                    Ok(p) => Json(serde_json::json!({
+                        "text": p.text,
+                        "tags": p.tags
+                    })),
+                    Err(_) => Json(serde_json::json!({"error": "invalid"})),
+                }
+            } else if payload.get("agent").is_some() {
+                match mcp_bridge::decode_request(&json) {
+                    Ok(p) => Json(serde_json::json!({
+                        "text": p.text,
+                        "tags": p.tags
+                    })),
+                    Err(_) => Json(serde_json::json!({"error": "invalid"})),
+                }
+            } else {
+                Json(serde_json::json!({"error": "unknown"}))
+            }
+        }
+
+        let app = Router::new().route("/translate", post(translate));
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
     }
 }
 

--- a/src/modules/mcp_bridge.rs
+++ b/src/modules/mcp_bridge.rs
@@ -1,0 +1,55 @@
+use crate::perception_adapter::{Modality, PerceptInput};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct McpRequest {
+    pub agent: String,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct McpResponse {
+    pub agent: String,
+    pub message: String,
+}
+
+pub fn decode_request(json: &str) -> serde_json::Result<PerceptInput> {
+    let req: McpRequest = serde_json::from_str(json)?;
+    Ok(PerceptInput {
+        modality: Modality::AgentMessage,
+        text: Some(req.message),
+        embedding: None,
+        image_data: None,
+        tags: vec![req.agent],
+    })
+}
+
+pub fn encode_response(agent: &str, message: &str) -> String {
+    let resp = McpResponse {
+        agent: agent.to_string(),
+        message: message.to_string(),
+    };
+    serde_json::to_string(&resp).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let req = McpRequest {
+            agent: "a1".into(),
+            message: "hello".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let percept = decode_request(&json).unwrap();
+        assert_eq!(percept.text.unwrap(), "hello");
+        assert_eq!(percept.tags[0], "a1");
+
+        let json_resp = encode_response("a1", "ok");
+        let resp: McpResponse = serde_json::from_str(&json_resp).unwrap();
+        assert_eq!(resp.agent, "a1");
+        assert_eq!(resp.message, "ok");
+    }
+}

--- a/src/modules/openmanus_bridge.rs
+++ b/src/modules/openmanus_bridge.rs
@@ -1,0 +1,55 @@
+use crate::perception_adapter::{Modality, PerceptInput};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct OpenManusRequest {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct OpenManusResponse {
+    pub role: String,
+    pub content: String,
+}
+
+pub fn decode_request(json: &str) -> serde_json::Result<PerceptInput> {
+    let req: OpenManusRequest = serde_json::from_str(json)?;
+    Ok(PerceptInput {
+        modality: Modality::AgentMessage,
+        text: Some(req.content),
+        embedding: None,
+        image_data: None,
+        tags: vec![req.role],
+    })
+}
+
+pub fn encode_response(role: &str, text: &str) -> String {
+    let resp = OpenManusResponse {
+        role: role.to_string(),
+        content: text.to_string(),
+    };
+    serde_json::to_string(&resp).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let req = OpenManusRequest {
+            role: "user".into(),
+            content: "ping".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let percept = decode_request(&json).unwrap();
+        assert_eq!(percept.text.unwrap(), "ping");
+        assert_eq!(percept.tags[0], "user");
+
+        let json_resp = encode_response("assistant", "pong");
+        let resp: OpenManusResponse = serde_json::from_str(&json_resp).unwrap();
+        assert_eq!(resp.role, "assistant");
+        assert_eq!(resp.content, "pong");
+    }
+}

--- a/tests/integration/agent_bridge_sit.rs
+++ b/tests/integration/agent_bridge_sit.rs
@@ -1,0 +1,18 @@
+use hipcortex::openmanus_bridge;
+use hipcortex::mcp_bridge;
+
+#[test]
+fn openmanus_to_percept() {
+    let json = r#"{"role":"user","content":"hello"}"#;
+    let percept = openmanus_bridge::decode_request(json).unwrap();
+    assert_eq!(percept.text.unwrap(), "hello");
+    assert_eq!(percept.tags[0], "user");
+}
+
+#[test]
+fn mcp_to_percept() {
+    let json = r#"{"agent":"a1","message":"ping"}"#;
+    let percept = mcp_bridge::decode_request(json).unwrap();
+    assert_eq!(percept.text.unwrap(), "ping");
+    assert_eq!(percept.tags[0], "a1");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -15,6 +15,7 @@ mod mcp_server_sit;
 #[cfg(all(feature = "web-server", feature = "grpc-server"))]
 mod mcp_server_uat;
 mod openmanus_integration_sit;
+mod agent_bridge_sit;
 mod plugin_host_sit;
 mod plugin_host_uat;
 mod rag_export_sit;


### PR DESCRIPTION
## Summary
- add OpenManus and MCP translators
- expose translation helpers in `IntegrationLayer`
- include optional simple UAT web server
- test agent bridges in integration suite

## Testing
- `cargo test --quiet`