### PR TITLE
Add monitoring service and dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,7 @@ Additional modules extend HipCortex further:
 - **A2A Protocol**: simple peer clients implement `A2AClient` to exchange procedural traces.
 - **Secure LLM Sandbox**: `sandbox::SecureLLMSandbox` renders templates with whitelisted variables before sending to LLMs.
 - **World Model Dashboard**: when the `web-server` feature is enabled, `dashboard::routes` exposes memory data for a lightweight web UI.
+- **Monitoring Service**: `monitoring::routes` serves live metrics for the Tauri dashboard.
 - **gRPC Server**: enabling the `grpc-server` feature spins up a Tonic-based service for adding and listing memory records.
  - **Effort Evaluator & Confidence Regulator**: measure reasoning effort and confidence decay to avoid collapse.
  - **Hypothesis Manager**: maintain multiple reasoning branches and a quantized state tree for backtracking.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ The following actions reinforce the math-driven data foundation:
 2. **Implement Runtime Validators** – check FSM reachability and graph connectivity automatically.
 3. **Add Property-Based Tests** – stress-test symbolic and temporal modules with proptest.
 4. **Pilot Statistical Monitoring** – collect moving averages and standard deviation for key metrics.
-5. **Automate Observability Dashboards** – integrate logs and metrics in the web dashboard.
+5. **Automate Observability Dashboards** – integrate logs and metrics in the web dashboard using the new `MonitoringService` and Tauri UI.
 6. **Deploy Enhancement Advisor** – surface reasoning-based suggestions for users to approve and refine.
 
 PRs for new modules and improvements are highly encouraged!

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -10,6 +10,7 @@ use crate::{
     aureus_bridge::AureusBridge,
     memory_record::{MemoryRecord, MemoryType},
     memory_store::MemoryStore,
+    monitoring::{MonitoringMetrics, MonitoringService},
     perception_adapter::{Modality, PerceptInput, PerceptionAdapter},
     procedural_cache::ProceduralCache,
     symbolic_store::SymbolicStore,
@@ -23,6 +24,7 @@ pub struct GuiState {
     procedural: Mutex<ProceduralCache>,
     aureus: Mutex<AureusBridge>,
     memory: Mutex<MemoryStore>,
+    monitoring: Mutex<MonitoringService>,
 }
 
 #[cfg(feature = "gui")]
@@ -34,6 +36,7 @@ impl GuiState {
             procedural: Mutex::new(ProceduralCache::new()),
             aureus: Mutex::new(AureusBridge::new()),
             memory: Mutex::new(MemoryStore::new("memory_gui.jsonl").unwrap()),
+            monitoring: Mutex::new(MonitoringService::new()),
         }
     }
 }
@@ -121,6 +124,13 @@ fn cli_command(state: State<GuiState>, cmd: String) -> String {
 }
 
 #[cfg(feature = "gui")]
+#[tauri::command]
+fn get_metrics(state: State<GuiState>) -> MonitoringMetrics {
+    let service = state.monitoring.lock().unwrap();
+    service.snapshot()
+}
+
+#[cfg(feature = "gui")]
 pub fn launch() -> tauri::Result<()> {
     tauri::Builder::default()
         .manage(GuiState::new())
@@ -128,7 +138,8 @@ pub fn launch() -> tauri::Result<()> {
             get_symbolic_graph,
             run_reflexion,
             send_perception,
-            cli_command
+            cli_command,
+            get_metrics
         ])
         .run(tauri::generate_context!())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod memory_processor;
 pub mod memory_query;
 pub mod memory_record;
 pub mod memory_store;
+pub mod monitoring;
 #[path = "modules/openmanus_bridge.rs"]
 pub mod openmanus_bridge;
 #[path = "modules/perception_adapter.rs"]

--- a/src/markov.rs
+++ b/src/markov.rs
@@ -51,8 +51,11 @@ where
     /// Predict the most likely next state given the current state.
     pub fn predict_next(&self, current: &T) -> Option<T> {
         let map = self.transitions.get(current)?;
-        map.iter()
-            .max_by_key(|(_, v)| *v)
-            .map(|(k, _)| k.clone())
+        map.iter().max_by_key(|(_, v)| *v).map(|(k, _)| k.clone())
+    }
+
+    /// Export transition counts for external reporting.
+    pub fn transition_counts(&self) -> HashMap<T, HashMap<T, usize>> {
+        self.transitions.clone()
     }
 }

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1,0 +1,83 @@
+use crate::markov::MarkovChain;
+use crate::poisson::PoissonBurst;
+use crate::procedural_cache::FSMState;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Aggregated metrics snapshot returned to the dashboard.
+#[derive(Serialize, Clone)]
+pub struct MonitoringMetrics {
+    pub request_rate: f32,
+    pub cache_hits: usize,
+    pub fsm_transitions: HashMap<String, HashMap<String, usize>>,
+    pub bursty: bool,
+}
+
+/// Gather runtime metrics for the engine.
+pub struct MonitoringService {
+    request_poisson: PoissonBurst,
+    cache_hits: usize,
+    fsm_markov: MarkovChain<FSMState>,
+}
+
+impl MonitoringService {
+    /// Create a new monitoring service with reasonable defaults.
+    pub fn new() -> Self {
+        Self {
+            request_poisson: PoissonBurst::new(0.2),
+            cache_hits: 0,
+            fsm_markov: MarkovChain::new(128),
+        }
+    }
+
+    /// Record a web request event.
+    pub fn record_request(&mut self) {
+        self.request_poisson.record_event();
+    }
+
+    /// Increment cache hit counter.
+    pub fn record_cache_hit(&mut self) {
+        self.cache_hits += 1;
+    }
+
+    /// Track state transitions from an FSM.
+    pub fn record_fsm_transition(&mut self, from: &FSMState, to: &FSMState) {
+        self.fsm_markov.record_transition(from, to);
+    }
+
+    /// Collect metrics in a serializable form.
+    pub fn snapshot(&self) -> MonitoringMetrics {
+        let mut map: HashMap<String, HashMap<String, usize>> = HashMap::new();
+        for (from, inner) in self.fsm_markov.transition_counts() {
+            let entry = map.entry(format!("{:?}", from)).or_default();
+            for (to, count) in inner {
+                entry.insert(format!("{:?}", to), count);
+            }
+        }
+        MonitoringMetrics {
+            request_rate: self.request_poisson.mean_rate(),
+            cache_hits: self.cache_hits,
+            fsm_transitions: map,
+            bursty: self.request_poisson.is_bursty(),
+        }
+    }
+}
+
+#[cfg(feature = "web-server")]
+use axum::{routing::get, Json, Router};
+
+#[cfg(feature = "web-server")]
+/// Build a router exposing a `/metrics` endpoint.
+pub fn routes(service: Arc<Mutex<MonitoringService>>) -> Router {
+    Router::new().route(
+        "/metrics",
+        get(move || {
+            let service = service.clone();
+            async move {
+                let metrics = service.lock().unwrap().snapshot();
+                Json(metrics)
+            }
+        }),
+    )
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -30,7 +30,13 @@
             <button onclick="runCli()">Run</button>
             <pre id="cli-out"></pre>
         </div>
+        <div id="metrics" class="panel">
+            <h2>Metrics</h2>
+            <canvas id="req-chart" height="150"></canvas>
+            <pre id="cache-hits">0</pre>
+        </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -24,4 +24,28 @@ async function runCli() {
 
 document.addEventListener('DOMContentLoaded', () => {
     loadGraph();
+    initMetrics();
 });
+
+let reqChart;
+function initMetrics() {
+    const ctx = document.getElementById('req-chart').getContext('2d');
+    reqChart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'req/s', data: [] }] },
+    });
+    setInterval(updateMetrics, 2000);
+}
+
+async function updateMetrics() {
+    const metrics = await window.__TAURI__.invoke('get_metrics');
+    document.getElementById('cache-hits').innerText = 'cache hits: ' + metrics.cache_hits;
+    const dataset = reqChart.data.datasets[0];
+    dataset.data.push(metrics.request_rate);
+    reqChart.data.labels.push('');
+    if (dataset.data.length > 20) {
+        dataset.data.shift();
+        reqChart.data.labels.shift();
+    }
+    reqChart.update();
+}


### PR DESCRIPTION
## Summary
- implement `MonitoringService` using PoissonBurst and MarkovChain
- export metrics via `/metrics` route
- expose metrics through the Tauri GUI
- visualize request rate and cache hits with Chart.js
- document monitoring service in architecture and roadmap

## Testing
- `cargo test --quiet`