### PR TITLE
Add LLM and world model connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ For WebAssembly extension, see `examples/plugin_host.rs` and run:
 `cargo run --example plugin_host --features plugin`.
 Detailed data model and extended architecture diagrams are available in [docs/data_model.md](docs/data_model.md) and [docs/architecture.md](docs/architecture.md).
 
+## LLM & World Model Connectors
+
+HipCortex ships with lightweight connectors for popular open-source models.
+- Mistral, Falcon, DeepSeek and custom local LLMs
+- World Model connector (JEPA style or mock implementation)
+
+Example usage:
+
+```sh
+cargo run -- llm-generate "Tell me a story"
+cargo run -- worldmodel-predict '{"state":"robot","action":"move"}'
+```
+
 ## 🛠️ Use Cases
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,8 @@ flowchart TD
     STM & Symb --> FSM[ProceduralCache (FSM)]
     FSM --> Reason[AureusBridge]
     Reason --> API[IntegrationLayer]
+    Reason --> LLMs[LLM Connectors]
+    FSM --> WM[World Model Connector]
 ```
 
 ## Solution Overview
@@ -36,6 +38,7 @@ extended as your use case grows.
 5. **Aureus Bridge** – plugs in reflexion or chain‑of‑thought reasoning loops.
 6. **Integration Layer** – exposes REST/gRPC endpoints and protocol adapters.
 7. **LLM Connectors** – clients for OpenAI, Claude, Ollama and other open-source models.
+8. **World Model Connector** – predicts next states for planning (JEPA or mock).
 
 This layered approach allows efficient reasoning on edge devices while remaining
 extensible for server deployments.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod backends {
 pub mod temporal_indexer;
 #[path = "modules/world_model.rs"]
 pub mod world_model;
+pub mod world_model_client;
 #[cfg(feature = "async-store")]
 pub use persistence::{AsyncFileBackend, AsyncMemoryBackend};
 #[cfg(feature = "grpc-server")]

--- a/src/llm_clients/deepseek_client.rs
+++ b/src/llm_clients/deepseek_client.rs
@@ -1,0 +1,71 @@
+use super::{LLMClient, LanguageModelClient};
+use reqwest::blocking::Client;
+use serde_json::json;
+
+/// DeepSeek HTTP connector.
+pub struct DeepSeekClient {
+    pub base_url: String,
+}
+
+impl DeepSeekClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+}
+
+impl LanguageModelClient for DeepSeekClient {
+    fn generate(&self, prompt: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/generate", self.base_url.trim_end_matches('/'));
+        let resp = client.post(&url).json(&json!({"prompt": prompt})).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["text"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let client = Client::new();
+        let url = format!("{}/embed", self.base_url.trim_end_matches('/'));
+        let resp = client.post(&url).json(&json!({"text": text})).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| {
+                    v["embedding"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|x| x.as_f64().map(|f| f as f32))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(_) => vec![],
+        }
+    }
+
+    fn chat(&self, history: Vec<String>, new_input: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/chat", self.base_url.trim_end_matches('/'));
+        let body = json!({"history": history, "input": new_input});
+        let resp = client.post(&url).json(&body).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["reply"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+}
+
+impl LLMClient for DeepSeekClient {
+    fn generate_response(&self, prompt: &str) -> String {
+        self.generate(prompt)
+    }
+}

--- a/src/llm_clients/falcon_client.rs
+++ b/src/llm_clients/falcon_client.rs
@@ -1,0 +1,71 @@
+use super::{LLMClient, LanguageModelClient};
+use reqwest::blocking::Client;
+use serde_json::json;
+
+/// Falcon model HTTP connector.
+pub struct FalconClient {
+    pub base_url: String,
+}
+
+impl FalconClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+}
+
+impl LanguageModelClient for FalconClient {
+    fn generate(&self, prompt: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/generate", self.base_url.trim_end_matches('/'));
+        let resp = client.post(&url).json(&json!({"prompt": prompt})).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["text"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let client = Client::new();
+        let url = format!("{}/embed", self.base_url.trim_end_matches('/'));
+        let resp = client.post(&url).json(&json!({"text": text})).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| {
+                    v["embedding"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|x| x.as_f64().map(|f| f as f32))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(_) => vec![],
+        }
+    }
+
+    fn chat(&self, history: Vec<String>, new_input: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/chat", self.base_url.trim_end_matches('/'));
+        let body = json!({"history": history, "input": new_input});
+        let resp = client.post(&url).json(&body).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["reply"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+}
+
+impl LLMClient for FalconClient {
+    fn generate_response(&self, prompt: &str) -> String {
+        self.generate(prompt)
+    }
+}

--- a/src/llm_clients/local_llm_client.rs
+++ b/src/llm_clients/local_llm_client.rs
@@ -1,0 +1,48 @@
+use super::{LLMClient, LanguageModelClient};
+use std::process::Command;
+
+/// Simple connector for a local command line model.
+pub struct LocalLLMClient {
+    pub command: String,
+}
+
+impl LocalLLMClient {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+        }
+    }
+
+    fn run(&self, arg: &str) -> String {
+        Command::new(&self.command)
+            .arg(arg)
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default()
+    }
+}
+
+impl LanguageModelClient for LocalLLMClient {
+    fn generate(&self, prompt: &str) -> String {
+        self.run(prompt)
+    }
+
+    fn embed(&self, _text: &str) -> Vec<f32> {
+        Vec::new()
+    }
+
+    fn chat(&self, history: Vec<String>, new_input: &str) -> String {
+        let mut joined = history.join("\n");
+        if !joined.is_empty() {
+            joined.push_str("\n");
+        }
+        joined.push_str(new_input);
+        self.run(&joined)
+    }
+}
+
+impl LLMClient for LocalLLMClient {
+    fn generate_response(&self, prompt: &str) -> String {
+        self.generate(prompt)
+    }
+}

--- a/src/llm_clients/mistral_client.rs
+++ b/src/llm_clients/mistral_client.rs
@@ -1,0 +1,73 @@
+use super::{LLMClient, LanguageModelClient};
+use reqwest::blocking::Client;
+use serde_json::json;
+
+/// Minimal HTTP client for Mistral-based endpoints.
+pub struct MistralClient {
+    pub base_url: String,
+}
+
+impl MistralClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+}
+
+impl LanguageModelClient for MistralClient {
+    fn generate(&self, prompt: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/generate", self.base_url.trim_end_matches('/'));
+        let body = json!({"prompt": prompt});
+        let resp = client.post(&url).json(&body).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["text"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let client = Client::new();
+        let url = format!("{}/embed", self.base_url.trim_end_matches('/'));
+        let body = json!({"text": text});
+        let resp = client.post(&url).json(&body).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| {
+                    v["embedding"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|x| x.as_f64().map(|f| f as f32))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(_) => vec![],
+        }
+    }
+
+    fn chat(&self, history: Vec<String>, new_input: &str) -> String {
+        let client = Client::new();
+        let url = format!("{}/chat", self.base_url.trim_end_matches('/'));
+        let body = json!({"history": history, "input": new_input});
+        let resp = client.post(&url).json(&body).send();
+        match resp {
+            Ok(r) => r
+                .json::<serde_json::Value>()
+                .map(|v| v["reply"].as_str().unwrap_or("").to_string())
+                .unwrap_or_default(),
+            Err(_) => "".into(),
+        }
+    }
+}
+
+impl LLMClient for MistralClient {
+    fn generate_response(&self, prompt: &str) -> String {
+        self.generate(prompt)
+    }
+}

--- a/src/llm_clients/mod.rs
+++ b/src/llm_clients/mod.rs
@@ -2,8 +2,19 @@ pub trait LLMClient: Send + Sync {
     fn generate_response(&self, prompt: &str) -> String;
 }
 
+/// Extended language model client used by plugin hosts.
+pub trait LanguageModelClient: Send + Sync {
+    fn generate(&self, prompt: &str) -> String;
+    fn embed(&self, text: &str) -> Vec<f32>;
+    fn chat(&self, history: Vec<String>, new_input: &str) -> String;
+}
+
 pub mod claude;
+pub mod deepseek_client;
+pub mod falcon_client;
 pub mod llama;
+pub mod local_llm_client;
+pub mod mistral_client;
 pub mod mock;
 pub mod ollama;
 pub mod openai;

--- a/src/memory_cli.rs
+++ b/src/memory_cli.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 
-use crate::llm_clients::LLMClient;
+use crate::llm_clients::{LLMClient, LanguageModelClient};
 use crate::memory_processor::MemoryProcessor;
 use crate::memory_query::MemoryQuery;
 use crate::memory_record::{MemoryRecord, MemoryType};
@@ -77,6 +77,10 @@ enum Commands {
         #[arg(long, default_value_t = 16)]
         capacity: usize,
     },
+    /// Generate text using a local or mocked LLM
+    LlmGenerate { prompt: String },
+    /// Predict next state using the world model connector
+    WorldModelPredict { input: String },
     /// Run a demonstration workflow
     RunWorkflow,
 }
@@ -198,6 +202,25 @@ pub fn run() -> Result<()> {
                 println!("{} {:?}", k, v);
             }
             sc.save(&cache)?;
+        }
+        Commands::LlmGenerate { prompt } => {
+            use crate::llm_clients::local_llm_client::LocalLLMClient;
+            let cmd = std::env::var("LOCAL_LLM_CMD").unwrap_or_else(|_| "echo".into());
+            let client = LocalLLMClient::new(cmd);
+            let resp = client.generate(&prompt);
+            println!("{}", resp);
+        }
+        Commands::WorldModelPredict { input } => {
+            use crate::world_model_client::{MockWorldModelClient, WorldModelClient};
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&input) {
+                let state = v["state"].as_str().unwrap_or("");
+                let action = v["action"].as_str().unwrap_or("");
+                let client = MockWorldModelClient;
+                let out = client.predict_next_state(state, action);
+                println!("{}", out);
+            } else {
+                println!("invalid input");
+            }
         }
         Commands::RunWorkflow => {
             use crate::backends::temporal_backend::TemporalFSMBackend;

--- a/src/world_model_client.rs
+++ b/src/world_model_client.rs
@@ -1,0 +1,13 @@
+/// Trait for predictive world models used by agents.
+pub trait WorldModelClient: Send + Sync {
+    fn predict_next_state(&self, current_state: &str, action: &str) -> String;
+}
+
+/// Simple mock world model used for tests and offline mode.
+pub struct MockWorldModelClient;
+
+impl WorldModelClient for MockWorldModelClient {
+    fn predict_next_state(&self, current_state: &str, action: &str) -> String {
+        format!("{} -> {}", current_state, action)
+    }
+}

--- a/tests/llm_clients.rs
+++ b/tests/llm_clients.rs
@@ -1,0 +1,89 @@
+use hipcortex::llm_clients::deepseek_client::DeepSeekClient;
+use hipcortex::llm_clients::falcon_client::FalconClient;
+use hipcortex::llm_clients::local_llm_client::LocalLLMClient;
+use hipcortex::llm_clients::mistral_client::MistralClient;
+use hipcortex::llm_clients::LanguageModelClient;
+use mockito::Server;
+
+#[test]
+fn mistral_client_endpoints() {
+    let mut server = Server::new();
+    let m1 = server
+        .mock("POST", "/generate")
+        .with_status(200)
+        .with_body("{\"text\":\"gen\"}")
+        .create();
+    let m2 = server
+        .mock("POST", "/embed")
+        .with_status(200)
+        .with_body("{\"embedding\":[1,2]}")
+        .create();
+    let m3 = server
+        .mock("POST", "/chat")
+        .with_status(200)
+        .with_body("{\"reply\":\"hi\"}")
+        .create();
+    let client = MistralClient::new(server.url());
+    assert_eq!(client.generate("p"), "gen");
+    assert_eq!(client.embed("t"), vec![1.0, 2.0]);
+    assert_eq!(client.chat(vec!["a".into()], "b"), "hi");
+    m1.assert();
+    m2.assert();
+    m3.assert();
+}
+
+#[test]
+fn falcon_client_endpoints() {
+    let mut server = Server::new();
+    server
+        .mock("POST", "/generate")
+        .with_status(200)
+        .with_body("{\"text\":\"ok\"}")
+        .create();
+    server
+        .mock("POST", "/embed")
+        .with_status(200)
+        .with_body("{\"embedding\":[3]}")
+        .create();
+    server
+        .mock("POST", "/chat")
+        .with_status(200)
+        .with_body("{\"reply\":\"c\"}")
+        .create();
+    let client = FalconClient::new(server.url());
+    assert_eq!(client.generate("x"), "ok");
+    assert_eq!(client.embed("t"), vec![3.0]);
+    assert_eq!(client.chat(vec![], "n"), "c");
+}
+
+#[test]
+fn deepseek_client_endpoints() {
+    let mut server = Server::new();
+    server
+        .mock("POST", "/generate")
+        .with_status(200)
+        .with_body("{\"text\":\"d\"}")
+        .create();
+    server
+        .mock("POST", "/embed")
+        .with_status(200)
+        .with_body("{\"embedding\":[4,5]}")
+        .create();
+    server
+        .mock("POST", "/chat")
+        .with_status(200)
+        .with_body("{\"reply\":\"r\"}")
+        .create();
+    let client = DeepSeekClient::new(server.url());
+    assert_eq!(client.generate("a"), "d");
+    assert_eq!(client.embed("b"), vec![4.0, 5.0]);
+    assert_eq!(client.chat(vec!["1".into()], "2"), "r");
+}
+
+#[test]
+fn local_llm_client_runs_command() {
+    let client = LocalLLMClient::new("echo");
+    assert_eq!(client.generate("hello"), "hello");
+    assert_eq!(client.chat(vec!["a".into()], "b"), "a\nb");
+    assert!(client.embed("x").is_empty());
+}

--- a/tests/world_model_client.rs
+++ b/tests/world_model_client.rs
@@ -1,0 +1,8 @@
+use hipcortex::world_model_client::{MockWorldModelClient, WorldModelClient};
+
+#[test]
+fn mock_predicts_next_state() {
+    let client = MockWorldModelClient;
+    let result = client.predict_next_state("robot", "move");
+    assert_eq!(result, "robot -> move");
+}


### PR DESCRIPTION
## Summary
- implement new LanguageModelClient trait
- add connectors for Mistral, Falcon, DeepSeek and local LLM
- add mockable WorldModelClient
- expose connectors via memory CLI
- document new connectors and update architecture diagram
- add unit tests for connectors

## Testing
- `cargo test --quiet`